### PR TITLE
feat: migrate backend from Supabase to Cloudflare (D1 + DO + Workers + R2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,33 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
 
+  deploy-api-worker:
+    runs-on: ubuntu-latest
+    if: |
+      needs.quality.result == 'success' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      github.ref == 'refs/heads/main'
+    needs: quality
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Deploy API Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: packages/api-worker
+          command: deploy
+
   deploy-frontend:
     runs-on: ubuntu-latest
     if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,8 +134,7 @@ jobs:
         run: bash scripts/build.sh
         env:
           CF_PAGES_BRANCH: main
-          EXPO_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          EXPO_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          EXPO_PUBLIC_BACKEND: cloudflare
           EXPO_PUBLIC_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       - name: Deploy to Cloudflare Pages

--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/react-native';
-import { GameStore } from '@werewolf/game-engine/engine/store';
 import { GameStatus } from '@werewolf/game-engine/models/GameStatus';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
@@ -15,15 +14,8 @@ import { ThemedToast } from '@/components/ThemedToast';
 import { APP_VERSION } from '@/config/version';
 import { AuthProvider, GameFacadeProvider, ServiceProvider } from '@/contexts';
 import { useGameFacade } from '@/contexts';
-import type { ServiceContextValue } from '@/contexts/ServiceContext';
 import { AppNavigator } from '@/navigation';
-import { GameFacade } from '@/services/facade/GameFacade';
-import { AvatarUploadService } from '@/services/feature/AvatarUploadService';
-import { SettingsService } from '@/services/feature/SettingsService';
-import { AudioService } from '@/services/infra/AudioService';
-import { AuthService } from '@/services/infra/AuthService';
-import { RoomService } from '@/services/infra/RoomService';
-import { RealtimeService } from '@/services/transport/RealtimeService';
+import { createAllServices } from '@/services/registry';
 import { ThemeProvider, useTheme } from '@/theme';
 import { AlertConfig, setAlertListener } from '@/utils/alert';
 import { signalAppReady } from '@/utils/appReady';
@@ -120,25 +112,9 @@ function AppContent() {
 export default function App() {
   appLog.debug('render');
 
-  // Composition root: 创建所有 service 实例（useState lazy init 保证仅创建一次）
-  const [services] = useState<ServiceContextValue>(() => {
-    const authService = new AuthService();
-    const roomService = new RoomService();
-    const settingsService = new SettingsService();
-    const audioService = new AudioService();
-    const avatarUploadService = new AvatarUploadService(authService);
-    return { authService, roomService, settingsService, audioService, avatarUploadService };
-  });
-
-  const [facade] = useState(
-    () =>
-      new GameFacade({
-        store: new GameStore(),
-        realtimeService: new RealtimeService(),
-        audioService: services.audioService,
-        roomService: services.roomService,
-      }),
-  );
+  // Composition root: 通过 ServiceRegistry 创建所有 service 实例
+  // useState lazy init 保证仅创建一次
+  const [{ services, facade }] = useState(() => createAllServices());
 
   return (
     <ErrorBoundary>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -265,4 +265,28 @@ export default tseslint.config(
       '@typescript-eslint/naming-convention': 'off',
     },
   },
+
+  // =========================================================================
+  // Cloudflare Workers (api-worker) — Workers runtime, no React
+  // Analogous to Supabase Edge Functions: allow console, disable React rules.
+  // =========================================================================
+  {
+    files: ['packages/api-worker/**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        projectService: false,
+      },
+    },
+    rules: {
+      // Workers use console for logging (no project logger available in this runtime)
+      'no-console': 'off',
+      // Disable React / React Native rules — no UI framework in Workers
+      'react/no-unknown-property': 'off',
+      'react-native/no-raw-text': 'off',
+      'react-native/split-platform-components': 'off',
+      'react-native/no-single-element-style-arrays': 'off',
+      'react-native/no-inline-styles': 'off',
+      '@typescript-eslint/naming-convention': 'off',
+    },
+  },
 );

--- a/packages/api-worker/migrations/0001_init.sql
+++ b/packages/api-worker/migrations/0001_init.sql
@@ -1,0 +1,30 @@
+-- Werewolf Game Judge — D1 Schema
+-- Mirrors Supabase rooms table structure for game_state persistence
+
+CREATE TABLE IF NOT EXISTS rooms (
+  id         TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  code       TEXT NOT NULL UNIQUE,
+  host_id    TEXT NOT NULL,
+  game_state TEXT,              -- JSON-serialized GameState
+  state_revision INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_rooms_code ON rooms(code);
+
+-- Users table for self-managed auth (anonymous + email)
+CREATE TABLE IF NOT EXISTS users (
+  id                TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  email             TEXT UNIQUE,
+  password_hash     TEXT,          -- bcrypt/scrypt hash, NULL for anonymous users
+  display_name      TEXT,
+  avatar_url        TEXT,
+  custom_avatar_url TEXT,
+  avatar_frame      TEXT,
+  is_anonymous      INTEGER NOT NULL DEFAULT 1,  -- SQLite boolean
+  created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);

--- a/packages/api-worker/package.json
+++ b/packages/api-worker/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@werewolf/api-worker",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "db:migrate:local": "wrangler d1 migrations apply werewolf-db --local",
+    "db:migrate:remote": "wrangler d1 migrations apply werewolf-db --remote",
+    "test": "echo 'No tests yet'"
+  },
+  "dependencies": {
+    "@werewolf/game-engine": "workspace:*",
+    "jose": "^6.0.11"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260401.0",
+    "wrangler": "^4.14.0"
+  }
+}

--- a/packages/api-worker/package.json
+++ b/packages/api-worker/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@werewolf/game-engine": "workspace:*",
+    "bcryptjs": "^3.0.3",
     "jose": "^6.0.11"
   },
   "devDependencies": {

--- a/packages/api-worker/src/durableObjects/GameRoom.ts
+++ b/packages/api-worker/src/durableObjects/GameRoom.ts
@@ -1,0 +1,155 @@
+/**
+ * GameRoom Durable Object — WebSocket Hibernation API 实时房间
+ *
+ * 每个房间对应一个 DO 实例，管理该房间所有玩家的 WebSocket 连接。
+ * Worker handler 在 game_state 变更后调用 DO 的 /broadcast 端点，
+ * DO 将新 state 推送给所有已连接客户端。
+ *
+ * 使用 Hibernation API（webSocketMessage / webSocketClose）降低内存开销：
+ * 空闲连接不占用 CPU 时间。
+ *
+ * 不包含游戏逻辑 — 纯粹的 WebSocket 广播中继。
+ */
+
+import type { Env } from '../env';
+
+interface WebSocketAttachment {
+  userId: string;
+  roomCode: string;
+  connectedAt: number;
+}
+
+export class GameRoom {
+  readonly state: DurableObjectState;
+  readonly env: Env;
+
+  constructor(state: DurableObjectState, env: Env) {
+    this.state = state;
+    this.env = env;
+  }
+
+  /**
+   * HTTP fetch handler — 两个入口：
+   * 1. GET /websocket — 客户端升级为 WebSocket
+   * 2. POST /broadcast — Worker handler 推送 state 变更
+   */
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === '/websocket') {
+      return this.#handleWebSocketUpgrade(request);
+    }
+
+    if (url.pathname === '/broadcast' && request.method === 'POST') {
+      return this.#handleBroadcast(request);
+    }
+
+    return new Response('Not Found', { status: 404 });
+  }
+
+  /**
+   * WebSocket 升级 — 客户端通过此端点建立持久连接。
+   * userId 和 roomCode 通过 query params 传递。
+   */
+  #handleWebSocketUpgrade(request: Request): Response {
+    const url = new URL(request.url);
+    const userId = url.searchParams.get('userId');
+    const roomCode = url.searchParams.get('roomCode');
+
+    if (!userId || !roomCode) {
+      return new Response('userId and roomCode required', { status: 400 });
+    }
+
+    const pair = new WebSocketPair();
+    const [client, server] = [pair[0], pair[1]];
+
+    // Attach metadata for identification
+    const attachment: WebSocketAttachment = {
+      userId,
+      roomCode,
+      connectedAt: Date.now(),
+    };
+
+    this.state.acceptWebSocket(server, [roomCode]);
+    (server as unknown as { serializeAttachment(a: unknown): void }).serializeAttachment(
+      attachment,
+    );
+
+    return new Response(null, {
+      status: 101,
+      webSocket: client,
+    });
+  }
+
+  /**
+   * Broadcast state to all connected WebSockets in this room.
+   * Called by Worker handler after processGameAction succeeds.
+   */
+  async #handleBroadcast(request: Request): Promise<Response> {
+    const body = (await request.json()) as {
+      state: unknown;
+      revision: number;
+      roomCode: string;
+    };
+
+    const message = JSON.stringify({
+      type: 'STATE_UPDATE',
+      state: body.state,
+      revision: body.revision,
+    });
+
+    const sockets = this.state.getWebSockets(body.roomCode);
+    let sent = 0;
+    for (const ws of sockets) {
+      try {
+        ws.send(message);
+        sent++;
+      } catch {
+        // Socket already closed — will be cleaned up in webSocketClose
+      }
+    }
+
+    return new Response(JSON.stringify({ sent }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  /**
+   * Hibernation API — 收到客户端消息时唤醒。
+   * 客户端可发送 ping / 自定义消息。
+   */
+  async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    const data = typeof message === 'string' ? message : new TextDecoder().decode(message);
+
+    try {
+      const parsed = JSON.parse(data);
+
+      if (parsed.type === 'ping') {
+        ws.send(JSON.stringify({ type: 'pong', ts: Date.now() }));
+      }
+    } catch {
+      // Non-JSON message — ignore
+    }
+  }
+
+  /**
+   * Hibernation API — WebSocket 关闭时清理。
+   */
+  async webSocketClose(
+    ws: WebSocket,
+    _code: number,
+    _reason: string,
+    _wasClean: boolean,
+  ): Promise<void> {
+    // Hibernation API automatically removes the socket from getWebSockets()
+    // No manual cleanup needed
+    ws.close();
+  }
+
+  /**
+   * Hibernation API — WebSocket 错误时清理。
+   */
+  async webSocketError(ws: WebSocket, _error: unknown): Promise<void> {
+    ws.close();
+  }
+}

--- a/packages/api-worker/src/env.ts
+++ b/packages/api-worker/src/env.ts
@@ -10,7 +10,7 @@ export interface Env {
   DB: D1Database;
 
   // ── R2 Bucket (Phase 3) ────────────────────────────────────────
-  AVATARS: R2Bucket;
+  AVATARS?: R2Bucket;
 
   // ── Durable Objects (Phase 2) ──────────────────────────────────
   GAME_ROOM: DurableObjectNamespace;

--- a/packages/api-worker/src/env.ts
+++ b/packages/api-worker/src/env.ts
@@ -10,7 +10,7 @@ export interface Env {
   DB: D1Database;
 
   // ── R2 Bucket (Phase 3) ────────────────────────────────────────
-  AVATARS?: R2Bucket;
+  AVATARS: R2Bucket;
 
   // ── Durable Objects (Phase 2) ──────────────────────────────────
   GAME_ROOM: DurableObjectNamespace;

--- a/packages/api-worker/src/env.ts
+++ b/packages/api-worker/src/env.ts
@@ -1,0 +1,27 @@
+/**
+ * Env — Cloudflare Worker 绑定类型定义
+ *
+ * 声明 D1、R2、DO 绑定和环境变量，与 wrangler.toml 保持一致。
+ * Phase 2/3 解注释后启用 GAME_ROOM / AVATARS。
+ */
+
+export interface Env {
+  // ── D1 Database ─────────────────────────────────────────────────
+  DB: D1Database;
+
+  // ── R2 Bucket (Phase 3) ────────────────────────────────────────
+  AVATARS: R2Bucket;
+
+  // ── Durable Objects (Phase 2) ──────────────────────────────────
+  GAME_ROOM: DurableObjectNamespace;
+
+  // ── Environment Variables ──────────────────────────────────────
+  ENVIRONMENT: string;
+  CORS_ORIGIN: string;
+
+  /** JWT signing secret — set via `wrangler secret put JWT_SECRET` */
+  JWT_SECRET: string;
+
+  /** Gemini API key — set via `wrangler secret put GEMINI_API_KEY` */
+  GEMINI_API_KEY?: string;
+}

--- a/packages/api-worker/src/handlers/authHandlers.ts
+++ b/packages/api-worker/src/handlers/authHandlers.ts
@@ -164,9 +164,19 @@ export async function handleSignIn(request: Request, env: Env): Promise<Response
     return jsonResponse({ error: 'invalid credentials' }, 401, env);
   }
 
-  const valid = await verifyPassword(body.password, user.password_hash);
-  if (!valid) {
+  const result = await verifyPassword(body.password, user.password_hash);
+  if (!result.valid) {
     return jsonResponse({ error: 'invalid credentials' }, 401, env);
+  }
+
+  // Lazy migration: bcrypt → PBKDF2 rehash on first successful login
+  if (result.needsRehash && result.newHash) {
+    await env.DB.prepare(
+      `UPDATE users SET password_hash = ?, updated_at = datetime('now') WHERE id = ?`,
+    )
+      .bind(result.newHash, user.id)
+      .run();
+    console.log(`Rehashed password for user ${user.id} (bcrypt → PBKDF2)`);
   }
 
   const token = await signToken(user.id, env, { email });

--- a/packages/api-worker/src/handlers/authHandlers.ts
+++ b/packages/api-worker/src/handlers/authHandlers.ts
@@ -1,0 +1,310 @@
+/**
+ * Auth Route Handlers — 自实现认证 API
+ *
+ * 覆盖匿名登录、邮箱注册/登录、用户资料更新、session 恢复。
+ * JWT 签发/验证，密码用 PBKDF2 哈希存储到 D1。
+ * 与 Supabase Auth 语义兼容（匿名 + 邮箱）。
+ */
+
+import type { Env } from '../env';
+import { extractBearerToken, signToken, verifyToken } from '../lib/auth';
+import { jsonResponse } from '../lib/cors';
+import { hashPassword, verifyPassword } from '../lib/password';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /auth/anonymous — 匿名登录
+// ─────────────────────────────────────────────────────────────────────────────
+export async function handleAnonymousSignIn(_request: Request, env: Env): Promise<Response> {
+  const userId = crypto.randomUUID();
+
+  await env.DB.prepare(`INSERT INTO users (id, is_anonymous) VALUES (?, 1)`).bind(userId).run();
+
+  const token = await signToken(userId, env, { anon: true });
+
+  return jsonResponse(
+    {
+      access_token: token,
+      user: { id: userId, is_anonymous: true, email: null, user_metadata: {} },
+    },
+    200,
+    env,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /auth/signup — 邮箱注册（或匿名升级）
+// ─────────────────────────────────────────────────────────────────────────────
+export async function handleSignUp(request: Request, env: Env): Promise<Response> {
+  const body = (await request.json()) as {
+    email?: string;
+    password?: string;
+    displayName?: string;
+  };
+
+  if (!body.email || !body.password) {
+    return jsonResponse({ error: 'email and password required' }, 400, env);
+  }
+
+  const email = body.email.toLowerCase().trim();
+  const displayName = body.displayName || email.split('@')[0];
+
+  // Check if request is from authenticated anonymous user (upgrade flow)
+  const bearerToken = extractBearerToken(request);
+  let existingUserId: string | null = null;
+  if (bearerToken) {
+    const payload = await verifyToken(bearerToken, env);
+    if (payload?.anon) {
+      existingUserId = payload.sub;
+    }
+  }
+
+  const passwordHash = await hashPassword(body.password);
+
+  if (existingUserId) {
+    // Anonymous → email upgrade: preserve UID
+    // Check email not already taken by another user
+    const existing = await env.DB.prepare('SELECT id FROM users WHERE email = ?')
+      .bind(email)
+      .first<{ id: string }>();
+
+    if (existing) {
+      return jsonResponse({ error: 'email already registered' }, 409, env);
+    }
+
+    await env.DB.prepare(
+      `UPDATE users
+       SET email = ?, password_hash = ?, display_name = ?,
+           is_anonymous = 0, updated_at = datetime('now')
+       WHERE id = ?`,
+    )
+      .bind(email, passwordHash, displayName, existingUserId)
+      .run();
+
+    const token = await signToken(existingUserId, env, { email });
+
+    return jsonResponse(
+      {
+        access_token: token,
+        user: {
+          id: existingUserId,
+          email,
+          is_anonymous: false,
+          user_metadata: { display_name: displayName },
+        },
+      },
+      200,
+      env,
+    );
+  }
+
+  // New user registration
+  const existing = await env.DB.prepare('SELECT id FROM users WHERE email = ?')
+    .bind(email)
+    .first<{ id: string }>();
+
+  if (existing) {
+    return jsonResponse({ error: 'email already registered' }, 409, env);
+  }
+
+  const userId = crypto.randomUUID();
+
+  await env.DB.prepare(
+    `INSERT INTO users (id, email, password_hash, display_name, is_anonymous)
+     VALUES (?, ?, ?, ?, 0)`,
+  )
+    .bind(userId, email, passwordHash, displayName)
+    .run();
+
+  const token = await signToken(userId, env, { email });
+
+  return jsonResponse(
+    {
+      access_token: token,
+      user: {
+        id: userId,
+        email,
+        is_anonymous: false,
+        user_metadata: { display_name: displayName },
+      },
+    },
+    200,
+    env,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /auth/signin — 邮箱密码登录
+// ─────────────────────────────────────────────────────────────────────────────
+export async function handleSignIn(request: Request, env: Env): Promise<Response> {
+  const body = (await request.json()) as {
+    email?: string;
+    password?: string;
+  };
+
+  if (!body.email || !body.password) {
+    return jsonResponse({ error: 'email and password required' }, 400, env);
+  }
+
+  const email = body.email.toLowerCase().trim();
+
+  const user = await env.DB.prepare(
+    'SELECT id, password_hash, display_name, avatar_url, custom_avatar_url, avatar_frame FROM users WHERE email = ?',
+  )
+    .bind(email)
+    .first<{
+      id: string;
+      password_hash: string;
+      display_name: string | null;
+      avatar_url: string | null;
+      custom_avatar_url: string | null;
+      avatar_frame: string | null;
+    }>();
+
+  if (!user || !user.password_hash) {
+    return jsonResponse({ error: 'invalid credentials' }, 401, env);
+  }
+
+  const valid = await verifyPassword(body.password, user.password_hash);
+  if (!valid) {
+    return jsonResponse({ error: 'invalid credentials' }, 401, env);
+  }
+
+  const token = await signToken(user.id, env, { email });
+
+  return jsonResponse(
+    {
+      access_token: token,
+      user: {
+        id: user.id,
+        email,
+        is_anonymous: false,
+        user_metadata: {
+          display_name: user.display_name,
+          avatar_url: user.avatar_url,
+          custom_avatar_url: user.custom_avatar_url,
+          avatar_frame: user.avatar_frame,
+        },
+      },
+    },
+    200,
+    env,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /auth/user — 获取当前用户信息（通过 JWT）
+// ─────────────────────────────────────────────────────────────────────────────
+export async function handleGetUser(request: Request, env: Env): Promise<Response> {
+  const token = extractBearerToken(request);
+  if (!token) {
+    return jsonResponse({ data: { user: null } }, 200, env);
+  }
+
+  const payload = await verifyToken(token, env);
+  if (!payload) {
+    return jsonResponse({ data: { user: null } }, 200, env);
+  }
+
+  const user = await env.DB.prepare(
+    `SELECT id, email, display_name, avatar_url, custom_avatar_url, avatar_frame, is_anonymous
+     FROM users WHERE id = ?`,
+  )
+    .bind(payload.sub)
+    .first<{
+      id: string;
+      email: string | null;
+      display_name: string | null;
+      avatar_url: string | null;
+      custom_avatar_url: string | null;
+      avatar_frame: string | null;
+      is_anonymous: number;
+    }>();
+
+  if (!user) {
+    return jsonResponse({ data: { user: null } }, 200, env);
+  }
+
+  return jsonResponse(
+    {
+      data: {
+        user: {
+          id: user.id,
+          email: user.email,
+          is_anonymous: user.is_anonymous === 1,
+          user_metadata: {
+            display_name: user.display_name,
+            avatar_url: user.avatar_url,
+            custom_avatar_url: user.custom_avatar_url,
+            avatar_frame: user.avatar_frame,
+          },
+        },
+      },
+    },
+    200,
+    env,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PUT /auth/profile — 更新用户资料
+// ─────────────────────────────────────────────────────────────────────────────
+export async function handleUpdateProfile(request: Request, env: Env): Promise<Response> {
+  const token = extractBearerToken(request);
+  if (!token) {
+    return jsonResponse({ error: 'unauthorized' }, 401, env);
+  }
+  const payload = await verifyToken(token, env);
+  if (!payload) {
+    return jsonResponse({ error: 'unauthorized' }, 401, env);
+  }
+
+  const body = (await request.json()) as {
+    displayName?: string;
+    avatarUrl?: string;
+    customAvatarUrl?: string;
+    avatarFrame?: string;
+  };
+
+  // Build dynamic SET clause for only provided fields
+  const sets: string[] = [];
+  const values: unknown[] = [];
+
+  if (body.displayName !== undefined) {
+    sets.push('display_name = ?');
+    values.push(body.displayName);
+  }
+  if (body.avatarUrl !== undefined) {
+    sets.push('avatar_url = ?');
+    values.push(body.avatarUrl);
+  }
+  if (body.customAvatarUrl !== undefined) {
+    sets.push('custom_avatar_url = ?');
+    values.push(body.customAvatarUrl);
+  }
+  if (body.avatarFrame !== undefined) {
+    sets.push('avatar_frame = ?');
+    values.push(body.avatarFrame);
+  }
+
+  if (sets.length === 0) {
+    return jsonResponse({ success: true }, 200, env);
+  }
+
+  sets.push("updated_at = datetime('now')");
+  values.push(payload.sub);
+
+  await env.DB.prepare(`UPDATE users SET ${sets.join(', ')} WHERE id = ?`)
+    .bind(...values)
+    .run();
+
+  return jsonResponse({ success: true }, 200, env);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /auth/signout — 登出（JWT 是无状态的，客户端清除 token 即可）
+// ─────────────────────────────────────────────────────────────────────────────
+export async function handleSignOut(_request: Request, env: Env): Promise<Response> {
+  // JWT is stateless — signout is client-side token removal.
+  // Server acknowledges; any future request with old token still validates until expiry.
+  return jsonResponse({ success: true }, 200, env);
+}

--- a/packages/api-worker/src/handlers/avatarUpload.ts
+++ b/packages/api-worker/src/handlers/avatarUpload.ts
@@ -1,0 +1,99 @@
+/**
+ * handlers/avatarUpload — R2 头像上传 API
+ *
+ * POST /avatar/upload — 接收 multipart/form-data，
+ * 压缩后存入 R2，返回公开可访问的 URL。
+ * 上传前自动清理用户旧头像。
+ */
+
+import type { Env } from '../env';
+import { extractBearerToken, verifyToken } from '../lib/auth';
+import { corsHeaders, jsonResponse } from '../lib/cors';
+
+/**
+ * 生成随机 hex 字符串
+ */
+function randomHex(bytes: number): string {
+  const buf = new Uint8Array(bytes);
+  crypto.getRandomValues(buf);
+  return [...buf].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export async function handleAvatarUpload(request: Request, env: Env): Promise<Response> {
+  // Auth check
+  const token = extractBearerToken(request);
+  if (!token) return jsonResponse({ error: 'unauthorized' }, 401, env);
+  const payload = await verifyToken(token, env);
+  if (!payload) return jsonResponse({ error: 'unauthorized' }, 401, env);
+
+  const userId = payload.sub;
+
+  // Parse multipart form data
+  const formData = await request.formData();
+  const rawFile = formData.get('file');
+
+  if (!rawFile || typeof rawFile === 'string') {
+    return jsonResponse({ error: 'file required' }, 400, env);
+  }
+
+  // Workers runtime: non-string FormData entries are File objects
+  const file = rawFile as unknown as File;
+
+  // Validate file type
+  if (!file.type.startsWith('image/')) {
+    return jsonResponse({ error: 'invalid file type' }, 400, env);
+  }
+
+  // Validate file size (max 5MB)
+  if (file.size > 5 * 1024 * 1024) {
+    return jsonResponse({ error: 'file too large (max 5MB)' }, 400, env);
+  }
+
+  // List and delete old avatars for this user
+  const oldObjects = await env.AVATARS.list({ prefix: `${userId}/` });
+  if (oldObjects.objects.length > 0) {
+    await Promise.all(oldObjects.objects.map((obj) => env.AVATARS.delete(obj.key)));
+  }
+
+  // Upload new avatar
+  const suffix = randomHex(4);
+  const ext = file.type === 'image/png' ? 'png' : 'jpg';
+  const key = `${userId}/${Date.now()}-${suffix}.${ext}`;
+
+  await env.AVATARS.put(key, file.stream(), {
+    httpMetadata: {
+      contentType: file.type,
+    },
+  });
+
+  // Build public URL
+  // R2 public access: https://<custom-domain>/<key> or via Worker serving
+  // For now, serve via the same Worker at /avatar/<key>
+  const publicUrl = new URL(request.url);
+  publicUrl.pathname = `/avatar/${key}`;
+  publicUrl.search = '';
+
+  return jsonResponse({ url: publicUrl.toString() }, 200, env);
+}
+
+/**
+ * GET /avatar/:userId/:filename — 从 R2 提供头像文件
+ */
+export async function handleAvatarServe(
+  request: Request,
+  env: Env,
+  key: string,
+): Promise<Response> {
+  const object = await env.AVATARS.get(key);
+
+  if (!object) {
+    return new Response('Not Found', { status: 404 });
+  }
+
+  const headers = new Headers(corsHeaders(env));
+  headers.set('Content-Type', object.httpMetadata?.contentType ?? 'image/jpeg');
+  headers.set('Cache-Control', 'public, max-age=31536000, immutable');
+  headers.set('ETag', object.httpEtag);
+
+  return new Response(object.body, { headers });
+}

--- a/packages/api-worker/src/handlers/avatarUpload.ts
+++ b/packages/api-worker/src/handlers/avatarUpload.ts
@@ -20,6 +20,8 @@ function randomHex(bytes: number): string {
 }
 
 export async function handleAvatarUpload(request: Request, env: Env): Promise<Response> {
+  if (!env.AVATARS) return jsonResponse({ error: 'avatar storage not configured' }, 503, env);
+
   // Auth check
   const token = extractBearerToken(request);
   if (!token) return jsonResponse({ error: 'unauthorized' }, 401, env);
@@ -84,6 +86,8 @@ export async function handleAvatarServe(
   env: Env,
   key: string,
 ): Promise<Response> {
+  if (!env.AVATARS) return jsonResponse({ error: 'avatar storage not configured' }, 503, env);
+
   const object = await env.AVATARS.get(key);
 
   if (!object) {

--- a/packages/api-worker/src/handlers/gameControl.ts
+++ b/packages/api-worker/src/handlers/gameControl.ts
@@ -1,0 +1,205 @@
+/**
+ * handlers/gameControl — 游戏生命周期 handlers (Workers 版)
+ *
+ * 与 Edge Functions 的 gameControl.ts 逻辑一致。
+ * 差异：`processGameAction` 多接 `db` 参数；`jsonResponse`/`missingParams` 多接 `env`。
+ */
+
+import {
+  handleAssignRoles,
+  handleFillWithBots,
+  handleMarkAllBotsViewed,
+  handleRestartGame,
+  handleSetRoleRevealAnimation,
+  handleShareNightReview,
+  handleStartNight,
+  handleUpdateTemplate,
+} from '@werewolf/game-engine/engine/handlers/gameControlHandler';
+import {
+  handleClearAllSeats,
+  handleJoinSeat,
+  handleLeaveMySeat,
+  handleUpdatePlayerProfile,
+} from '@werewolf/game-engine/engine/handlers/seatHandler';
+import { handleViewedRole } from '@werewolf/game-engine/engine/handlers/viewedRoleHandler';
+import type {
+  JoinSeatIntent,
+  LeaveMySeatIntent,
+  UpdatePlayerProfileIntent,
+} from '@werewolf/game-engine/engine/intents/types';
+import type { RoleId } from '@werewolf/game-engine/models/roles';
+import type { GameState } from '@werewolf/game-engine/protocol/types';
+import type { RoleRevealAnimation } from '@werewolf/game-engine/types/RoleRevealAnimation';
+
+import { broadcastIfNeeded } from '../lib/broadcast';
+import { jsonResponse } from '../lib/cors';
+import { processGameAction } from '../lib/gameStateManager';
+import {
+  buildHandlerContext,
+  createSimpleHandler,
+  extractAudioActions,
+  type HandlerFn,
+  isValidSeat,
+  missingParams,
+  resultToStatus,
+} from './shared';
+
+// ── Simple intent-only handlers ─────────────────────────────────────────────
+
+export const handleAssign = createSimpleHandler(handleAssignRoles, {
+  type: 'ASSIGN_ROLES' as const,
+});
+export const handleFillBots = createSimpleHandler(handleFillWithBots, {
+  type: 'FILL_WITH_BOTS' as const,
+});
+export const handleMarkBotsViewed = createSimpleHandler(handleMarkAllBotsViewed, {
+  type: 'MARK_ALL_BOTS_VIEWED' as const,
+});
+export const handleClearSeats = createSimpleHandler(handleClearAllSeats, {
+  type: 'CLEAR_ALL_SEATS' as const,
+});
+export const handleRestart = createSimpleHandler(handleRestartGame, {
+  type: 'RESTART_GAME' as const,
+});
+
+// ── Parameterized handlers ──────────────────────────────────────────────────
+
+export const handleSeat: HandlerFn = async (req, env) => {
+  const body = (await req.json()) as {
+    roomCode?: string;
+    action?: string;
+    uid?: string;
+    seat?: number;
+    displayName?: string;
+    avatarUrl?: string;
+    avatarFrame?: string;
+  };
+  const { roomCode, action, uid, seat, displayName, avatarUrl, avatarFrame } = body;
+
+  if (!roomCode || !uid || !action) return missingParams(env);
+  if (action !== 'sit' && action !== 'standup') {
+    return jsonResponse({ success: false, reason: 'INVALID_ACTION' }, 400, env);
+  }
+  if (action === 'sit' && (seat == null || !isValidSeat(seat))) {
+    return jsonResponse({ success: false, reason: 'MISSING_SEAT' }, 400, env);
+  }
+
+  const result = await processGameAction(env.DB, roomCode, (state: GameState) => {
+    const handlerCtx = buildHandlerContext(state, uid);
+    if (action === 'sit') {
+      const intent: JoinSeatIntent = {
+        type: 'JOIN_SEAT',
+        payload: { seat: seat!, uid, displayName: displayName ?? '', avatarUrl, avatarFrame },
+      };
+      return handleJoinSeat(intent, handlerCtx);
+    } else {
+      const intent: LeaveMySeatIntent = { type: 'LEAVE_MY_SEAT', payload: { uid } };
+      return handleLeaveMySeat(intent, handlerCtx);
+    }
+  });
+  broadcastIfNeeded(env, roomCode, result);
+  return jsonResponse(result, resultToStatus(result), env);
+};
+
+export const handleSetAnimation: HandlerFn = async (req, env) => {
+  const body = (await req.json()) as { roomCode?: string; animation?: string };
+  const { roomCode, animation } = body;
+  if (!roomCode || !animation) return missingParams(env);
+
+  const result = await processGameAction(env.DB, roomCode, (state: GameState) => {
+    const handlerCtx = buildHandlerContext(state, state.hostUid);
+    return handleSetRoleRevealAnimation(
+      { type: 'SET_ROLE_REVEAL_ANIMATION', animation: animation as RoleRevealAnimation },
+      handlerCtx,
+    );
+  });
+  broadcastIfNeeded(env, roomCode, result);
+  return jsonResponse(result, resultToStatus(result), env);
+};
+
+export const handleStart: HandlerFn = async (req, env) => {
+  const body = (await req.json()) as { roomCode?: string };
+  const { roomCode } = body;
+  if (!roomCode) return missingParams(env);
+
+  const result = await processGameAction(env.DB, roomCode, (state: GameState) => {
+    const handlerCtx = buildHandlerContext(state, state.hostUid);
+    const handlerResult = handleStartNight({ type: 'START_NIGHT' }, handlerCtx);
+    if (!handlerResult.success) return handlerResult;
+
+    const extraActions = extractAudioActions(handlerResult.sideEffects);
+    if (extraActions.length > 0) {
+      return { ...handlerResult, actions: [...handlerResult.actions, ...extraActions] };
+    }
+    return handlerResult;
+  });
+  broadcastIfNeeded(env, roomCode, result);
+  return jsonResponse(result, resultToStatus(result), env);
+};
+
+export const handleUpdateTemplateRoute: HandlerFn = async (req, env) => {
+  const body = (await req.json()) as { roomCode?: string; templateRoles?: string[] };
+  const { roomCode, templateRoles } = body;
+  if (!roomCode || !templateRoles || !Array.isArray(templateRoles)) {
+    return missingParams(env);
+  }
+
+  const result = await processGameAction(env.DB, roomCode, (state: GameState) => {
+    const handlerCtx = buildHandlerContext(state, state.hostUid);
+    return handleUpdateTemplate(
+      { type: 'UPDATE_TEMPLATE', payload: { templateRoles: templateRoles as RoleId[] } },
+      handlerCtx,
+    );
+  });
+  broadcastIfNeeded(env, roomCode, result);
+  return jsonResponse(result, resultToStatus(result), env);
+};
+
+export const handleViewRole: HandlerFn = async (req, env) => {
+  const body = (await req.json()) as { roomCode?: string; uid?: string; seat?: number };
+  const { roomCode, uid, seat } = body;
+  if (!roomCode || !uid || !isValidSeat(seat)) return missingParams(env);
+
+  const result = await processGameAction(env.DB, roomCode, (state: GameState) => {
+    const handlerCtx = buildHandlerContext(state, uid);
+    return handleViewedRole({ type: 'VIEWED_ROLE', payload: { seat } }, handlerCtx);
+  });
+  broadcastIfNeeded(env, roomCode, result);
+  return jsonResponse(result, resultToStatus(result), env);
+};
+
+export const handleShareReview: HandlerFn = async (req, env) => {
+  const body = (await req.json()) as { roomCode?: string; allowedSeats?: number[] };
+  const { roomCode, allowedSeats } = body;
+  if (!roomCode || !Array.isArray(allowedSeats)) return missingParams(env);
+
+  const result = await processGameAction(env.DB, roomCode, (state: GameState) => {
+    const handlerCtx = buildHandlerContext(state, state.hostUid);
+    return handleShareNightReview({ type: 'SHARE_NIGHT_REVIEW', allowedSeats }, handlerCtx);
+  });
+  broadcastIfNeeded(env, roomCode, result);
+  return jsonResponse(result, resultToStatus(result), env);
+};
+
+export const handleUpdateProfileRoute: HandlerFn = async (req, env) => {
+  const body = (await req.json()) as {
+    roomCode?: string;
+    uid?: string;
+    displayName?: string;
+    avatarUrl?: string;
+    avatarFrame?: string;
+  };
+  const { roomCode, uid, displayName, avatarUrl, avatarFrame } = body;
+  if (!roomCode || !uid) return missingParams(env);
+
+  const result = await processGameAction(env.DB, roomCode, (state: GameState) => {
+    const handlerCtx = buildHandlerContext(state, uid);
+    const intent: UpdatePlayerProfileIntent = {
+      type: 'UPDATE_PLAYER_PROFILE',
+      payload: { uid, displayName, avatarUrl, avatarFrame },
+    };
+    return handleUpdatePlayerProfile(intent, handlerCtx);
+  });
+  broadcastIfNeeded(env, roomCode, result);
+  return jsonResponse(result, resultToStatus(result), env);
+};

--- a/packages/api-worker/src/handlers/geminiProxy.ts
+++ b/packages/api-worker/src/handlers/geminiProxy.ts
@@ -1,0 +1,70 @@
+/**
+ * Gemini Proxy Handler (Workers 版)
+ *
+ * 与 Edge Functions 的 gemini-proxy/index.ts 逻辑一致：
+ * 透明代理 Gemini API（OpenAI 兼容层），服务端注入 API key。
+ * 支持普通请求和 SSE 流式响应。
+ */
+
+import type { Env } from '../env';
+import { corsHeaders, jsonResponse } from '../lib/cors';
+
+const GEMINI_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta/openai';
+const MAX_TOKENS_CAP = 4096;
+
+export async function handleGeminiProxy(request: Request, env: Env): Promise<Response> {
+  if (!env.GEMINI_API_KEY) {
+    return jsonResponse({ error: 'GEMINI_API_KEY not configured' }, 500, env);
+  }
+
+  try {
+    const body = (await request.json()) as {
+      messages?: unknown;
+      model?: string;
+      stream?: boolean;
+      temperature?: number;
+      max_tokens?: number;
+    };
+
+    const sanitizedBody = {
+      messages: body.messages,
+      model: body.model,
+      stream: body.stream,
+      ...(body.temperature != null && { temperature: body.temperature }),
+      ...(body.max_tokens != null && {
+        max_tokens: Math.min(Number(body.max_tokens) || MAX_TOKENS_CAP, MAX_TOKENS_CAP),
+      }),
+    };
+
+    const geminiResponse = await fetch(`${GEMINI_BASE_URL}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${env.GEMINI_API_KEY}`,
+      },
+      body: JSON.stringify(sanitizedBody),
+    });
+
+    const cors = corsHeaders(env);
+
+    if (sanitizedBody.stream) {
+      return new Response(geminiResponse.body, {
+        headers: {
+          ...cors,
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+        },
+        status: geminiResponse.status,
+      });
+    }
+
+    const data = await geminiResponse.json();
+    return new Response(JSON.stringify(data), {
+      headers: { ...cors, 'Content-Type': 'application/json' },
+      status: geminiResponse.status,
+    });
+  } catch (error) {
+    console.error('[gemini-proxy] Unhandled error:', error);
+    return jsonResponse({ error: 'Internal server error' }, 500, env);
+  }
+}

--- a/packages/api-worker/src/handlers/night.ts
+++ b/packages/api-worker/src/handlers/night.ts
@@ -1,0 +1,297 @@
+/**
+ * handlers/night — 夜晚阶段 handlers (Workers 版)
+ *
+ * 与 Edge Functions 的 night.ts 逻辑一致。
+ */
+
+import { handleSubmitAction } from '@werewolf/game-engine/engine/handlers/actionHandler';
+import {
+  handleEndNight,
+  handleSetAudioPlaying,
+} from '@werewolf/game-engine/engine/handlers/stepTransitionHandler';
+import { handleSetWolfRobotHunterStatusViewed } from '@werewolf/game-engine/engine/handlers/wolfRobotHunterGateHandler';
+import type {
+  EndNightIntent,
+  SetAudioPlayingIntent,
+  SubmitActionIntent,
+} from '@werewolf/game-engine/engine/intents/types';
+import type { StateAction } from '@werewolf/game-engine/engine/reducer/types';
+import { GameStatus } from '@werewolf/game-engine/models/GameStatus';
+import type { RoleId } from '@werewolf/game-engine/models/roles';
+import type { SchemaId } from '@werewolf/game-engine/models/roles/spec/schemas';
+import { SCHEMAS } from '@werewolf/game-engine/models/roles/spec/schemas';
+import type { GameState } from '@werewolf/game-engine/protocol/types';
+
+import { broadcastIfNeeded } from '../lib/broadcast';
+import { jsonResponse } from '../lib/cors';
+import { processGameAction } from '../lib/gameStateManager';
+import {
+  buildHandlerContext,
+  extractAudioActions,
+  type HandlerFn,
+  isValidSeat,
+  missingParams,
+  resultToStatus,
+} from './shared';
+
+// ── Night handlers ──────────────────────────────────────────────────────────
+
+export const handleAction: HandlerFn = async (req, env) => {
+  const body = (await req.json()) as {
+    roomCode?: string;
+    seat?: number;
+    role?: string;
+    target?: number | null;
+    extra?: unknown;
+  };
+  const { roomCode, seat, role, target, extra } = body;
+  if (!roomCode || !isValidSeat(seat) || !role) return missingParams(env);
+
+  const result = await processGameAction(
+    env.DB,
+    roomCode,
+    (state: GameState) => {
+      const handlerCtx = buildHandlerContext(state, state.hostUid);
+      const intent: SubmitActionIntent = {
+        type: 'SUBMIT_ACTION',
+        payload: { seat, role: role as RoleId, target: target ?? null, extra },
+      };
+      return handleSubmitAction(intent, handlerCtx);
+    },
+    { enabled: true },
+  );
+  broadcastIfNeeded(env, roomCode, result);
+  return jsonResponse(result, resultToStatus(result), env);
+};
+
+export const handleAudioAck: HandlerFn = async (req, env) => {
+  const body = (await req.json()) as { roomCode?: string };
+  const { roomCode } = body;
+  if (!roomCode) return missingParams(env);
+
+  const result = await processGameAction(
+    env.DB,
+    roomCode,
+    (state) => {
+      if (
+        !state.isAudioPlaying &&
+        (!state.pendingAudioEffects || state.pendingAudioEffects.length === 0)
+      ) {
+        return { success: true, actions: [] };
+      }
+      return {
+        success: true,
+        actions: [
+          { type: 'CLEAR_PENDING_AUDIO_EFFECTS' as const },
+          { type: 'SET_AUDIO_PLAYING' as const, payload: { isPlaying: false } },
+        ],
+      };
+    },
+    { enabled: true },
+  );
+  broadcastIfNeeded(env, roomCode, result);
+  return jsonResponse(result, resultToStatus(result), env);
+};
+
+export const handleAudioGate: HandlerFn = async (req, env) => {
+  const body = (await req.json()) as { roomCode?: string; isPlaying?: boolean };
+  const { roomCode, isPlaying } = body;
+  if (!roomCode || typeof isPlaying !== 'boolean') return missingParams(env);
+
+  const result = await processGameAction(env.DB, roomCode, (state: GameState) => {
+    const handlerCtx = buildHandlerContext(state, state.hostUid);
+    const intent: SetAudioPlayingIntent = {
+      type: 'SET_AUDIO_PLAYING',
+      payload: { isPlaying },
+    };
+    return handleSetAudioPlaying(intent, handlerCtx);
+  });
+  broadcastIfNeeded(env, roomCode, result);
+  return jsonResponse(result, resultToStatus(result), env);
+};
+
+export const handleEnd: HandlerFn = async (req, env) => {
+  const body = (await req.json()) as { roomCode?: string };
+  const { roomCode } = body;
+  if (!roomCode) return missingParams(env);
+
+  const result = await processGameAction(env.DB, roomCode, (state: GameState) => {
+    const handlerCtx = buildHandlerContext(state, state.hostUid);
+    const intent: EndNightIntent = { type: 'END_NIGHT' };
+    const handlerResult = handleEndNight(intent, handlerCtx);
+    if (!handlerResult.success) return handlerResult;
+
+    const extraActions = extractAudioActions(handlerResult.sideEffects);
+    if (extraActions.length > 0) {
+      return { ...handlerResult, actions: [...handlerResult.actions, ...extraActions] };
+    }
+    return handlerResult;
+  });
+  broadcastIfNeeded(env, roomCode, result);
+  return jsonResponse(result, resultToStatus(result), env);
+};
+
+export const handleProgression: HandlerFn = async (req, env) => {
+  const body = (await req.json()) as { roomCode?: string };
+  const { roomCode } = body;
+  if (!roomCode) return missingParams(env);
+
+  const result = await processGameAction(
+    env.DB,
+    roomCode,
+    (state) => {
+      if (state.status !== GameStatus.Ongoing) {
+        return { success: false, reason: 'not_ongoing', actions: [] };
+      }
+      return { success: true, actions: [] };
+    },
+    { enabled: true },
+  );
+  broadcastIfNeeded(env, roomCode, result);
+  return jsonResponse(result, resultToStatus(result), env);
+};
+
+export const handleRevealAck: HandlerFn = async (req, env) => {
+  const body = (await req.json()) as { roomCode?: string };
+  const { roomCode } = body;
+  if (!roomCode) return missingParams(env);
+
+  const result = await processGameAction(
+    env.DB,
+    roomCode,
+    (state) => {
+      if (!state.pendingRevealAcks || state.pendingRevealAcks.length === 0) {
+        return { success: false, reason: 'no_pending_acks', actions: [] };
+      }
+      return {
+        success: true,
+        actions: [{ type: 'CLEAR_REVEAL_ACKS' as const }],
+        sideEffects: [{ type: 'BROADCAST_STATE' as const }],
+      };
+    },
+    { enabled: true },
+  );
+  broadcastIfNeeded(env, roomCode, result);
+  return jsonResponse(result, resultToStatus(result), env);
+};
+
+export const handleWolfRobotViewed: HandlerFn = async (req, env) => {
+  const body = (await req.json()) as { roomCode?: string; seat?: number };
+  const { roomCode, seat } = body;
+  if (!roomCode || !isValidSeat(seat)) return missingParams(env);
+
+  const result = await processGameAction(
+    env.DB,
+    roomCode,
+    (state: GameState) => {
+      const handlerCtx = buildHandlerContext(state, state.hostUid);
+      return handleSetWolfRobotHunterStatusViewed(handlerCtx, {
+        type: 'SET_WOLF_ROBOT_HUNTER_STATUS_VIEWED',
+        seat,
+      });
+    },
+    { enabled: true },
+  );
+  broadcastIfNeeded(env, roomCode, result);
+  return jsonResponse(result, resultToStatus(result), env);
+};
+
+export const handleGroupConfirmAck: HandlerFn = async (req, env) => {
+  const body = (await req.json()) as { roomCode?: string; seat?: number; uid?: string };
+  const { roomCode, seat, uid } = body;
+  if (!roomCode || !isValidSeat(seat) || !uid) return missingParams(env);
+
+  const result = await processGameAction(
+    env.DB,
+    roomCode,
+    (state: GameState) => {
+      if (state.status !== GameStatus.Ongoing) {
+        return { success: false, reason: 'not_ongoing', actions: [] };
+      }
+      const stepId = state.currentStepId;
+      if (!stepId) return { success: false, reason: 'no_current_step', actions: [] };
+      const schema = SCHEMAS[stepId as SchemaId];
+      if (!schema || schema.kind !== 'groupConfirm') {
+        return { success: false, reason: 'not_group_confirm_step', actions: [] };
+      }
+      const player = state.players[seat];
+      if (!player) return { success: false, reason: 'no_player_at_seat', actions: [] };
+      if (player.uid !== uid && uid !== state.hostUid) {
+        return { success: false, reason: 'uid_mismatch', actions: [] };
+      }
+
+      const isConversionReveal = stepId === 'awakenedGargoyleConvertReveal';
+      const isCupidLoversReveal = stepId === 'cupidLoversReveal';
+      const acks = isConversionReveal
+        ? (state.conversionRevealAcks ?? [])
+        : isCupidLoversReveal
+          ? (state.cupidLoversRevealAcks ?? [])
+          : (state.piperRevealAcks ?? []);
+      if (acks.includes(seat)) return { success: true, actions: [] };
+
+      const actions: StateAction[] = isConversionReveal
+        ? [{ type: 'ADD_CONVERSION_REVEAL_ACK', payload: { seat } }]
+        : isCupidLoversReveal
+          ? [{ type: 'ADD_CUPID_LOVERS_REVEAL_ACK', payload: { seat } }]
+          : [{ type: 'ADD_PIPER_REVEAL_ACK', payload: { seat } }];
+
+      return { success: true, actions };
+    },
+    { enabled: true },
+  );
+  broadcastIfNeeded(env, roomCode, result);
+  return jsonResponse(result, resultToStatus(result), env);
+};
+
+export const handleMarkBotsGroupConfirmed: HandlerFn = async (req, env) => {
+  const body = (await req.json()) as { roomCode?: string };
+  const { roomCode } = body;
+  if (!roomCode) return missingParams(env);
+
+  const result = await processGameAction(
+    env.DB,
+    roomCode,
+    (state: GameState) => {
+      if (!state.debugMode?.botsEnabled) {
+        return { success: false, reason: 'debug_not_enabled', actions: [] };
+      }
+      if (state.status !== GameStatus.Ongoing) {
+        return { success: false, reason: 'not_ongoing', actions: [] };
+      }
+      const stepId = state.currentStepId;
+      if (!stepId) return { success: false, reason: 'no_current_step', actions: [] };
+      const schema = SCHEMAS[stepId as SchemaId];
+      if (!schema || schema.kind !== 'groupConfirm') {
+        return { success: false, reason: 'not_group_confirm_step', actions: [] };
+      }
+
+      const isConversionReveal = stepId === 'awakenedGargoyleConvertReveal';
+      const isCupidLoversReveal = stepId === 'cupidLoversReveal';
+      const existingAcks = isConversionReveal
+        ? (state.conversionRevealAcks ?? [])
+        : isCupidLoversReveal
+          ? (state.cupidLoversRevealAcks ?? [])
+          : (state.piperRevealAcks ?? []);
+
+      const actions: StateAction[] = [];
+      for (const [seatStr, player] of Object.entries(state.players)) {
+        if (!player?.isBot) continue;
+        const seatNum = Number.parseInt(seatStr, 10);
+        if (existingAcks.includes(seatNum)) continue;
+
+        if (isConversionReveal) {
+          actions.push({ type: 'ADD_CONVERSION_REVEAL_ACK', payload: { seat: seatNum } });
+        } else if (isCupidLoversReveal) {
+          actions.push({ type: 'ADD_CUPID_LOVERS_REVEAL_ACK', payload: { seat: seatNum } });
+        } else {
+          actions.push({ type: 'ADD_PIPER_REVEAL_ACK', payload: { seat: seatNum } });
+        }
+      }
+
+      return { success: true, actions };
+    },
+    { enabled: true },
+  );
+  broadcastIfNeeded(env, roomCode, result);
+  return jsonResponse(result, resultToStatus(result), env);
+};

--- a/packages/api-worker/src/handlers/roomHandlers.ts
+++ b/packages/api-worker/src/handlers/roomHandlers.ts
@@ -1,0 +1,169 @@
+/**
+ * handlers/roomHandlers — 房间 CRUD API（Workers 版）
+ *
+ * 提供 /room/create、/room/get、/room/delete、/room/state、/room/revision 端点。
+ * D1 直读直写，不经过 game-engine handler。
+ */
+
+import type { Env } from '../env';
+import { extractBearerToken, verifyToken } from '../lib/auth';
+import { jsonResponse } from '../lib/cors';
+
+// ── POST /room/create ───────────────────────────────────────────────────────
+export async function handleCreateRoom(request: Request, env: Env): Promise<Response> {
+  const token = extractBearerToken(request);
+  if (!token) return jsonResponse({ error: 'unauthorized' }, 401, env);
+  const payload = await verifyToken(token, env);
+  if (!payload) return jsonResponse({ error: 'unauthorized' }, 401, env);
+
+  const body = (await request.json()) as {
+    roomCode?: string;
+    initialState?: unknown;
+  };
+
+  if (!body.roomCode) {
+    return jsonResponse({ error: 'roomCode required' }, 400, env);
+  }
+
+  const params: string[] = [crypto.randomUUID(), body.roomCode, payload.sub];
+  let sql = 'INSERT INTO rooms (id, code, host_id) VALUES (?, ?, ?)';
+
+  if (body.initialState) {
+    sql =
+      'INSERT INTO rooms (id, code, host_id, game_state, state_revision) VALUES (?, ?, ?, ?, 1)';
+    params.push(JSON.stringify(body.initialState));
+    params.push('1');
+  }
+
+  try {
+    await env.DB.prepare(sql)
+      .bind(...params)
+      .run();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes('UNIQUE') || message.includes('constraint')) {
+      return jsonResponse({ error: 'room_code_conflict' }, 409, env);
+    }
+    throw err;
+  }
+
+  return jsonResponse(
+    {
+      room: {
+        roomNumber: body.roomCode,
+        hostUid: payload.sub,
+        createdAt: new Date().toISOString(),
+      },
+    },
+    200,
+    env,
+  );
+}
+
+// ── POST /room/get ──────────────────────────────────────────────────────────
+export async function handleGetRoom(request: Request, env: Env): Promise<Response> {
+  const body = (await request.json()) as { roomCode?: string };
+  if (!body.roomCode) {
+    return jsonResponse({ error: 'roomCode required' }, 400, env);
+  }
+
+  const row = await env.DB.prepare('SELECT id, code, host_id, created_at FROM rooms WHERE code = ?')
+    .bind(body.roomCode)
+    .first<{ id: string; code: string; host_id: string; created_at: string }>();
+
+  if (!row) {
+    return jsonResponse({ room: null }, 200, env);
+  }
+
+  return jsonResponse(
+    {
+      room: {
+        roomNumber: row.code,
+        hostUid: row.host_id,
+        createdAt: row.created_at,
+      },
+    },
+    200,
+    env,
+  );
+}
+
+// ── POST /room/delete ───────────────────────────────────────────────────────
+export async function handleDeleteRoom(request: Request, env: Env): Promise<Response> {
+  const token = extractBearerToken(request);
+  if (!token) return jsonResponse({ error: 'unauthorized' }, 401, env);
+  const payload = await verifyToken(token, env);
+  if (!payload) return jsonResponse({ error: 'unauthorized' }, 401, env);
+
+  const body = (await request.json()) as { roomCode?: string };
+  if (!body.roomCode) {
+    return jsonResponse({ error: 'roomCode required' }, 400, env);
+  }
+
+  await env.DB.prepare('DELETE FROM rooms WHERE code = ?').bind(body.roomCode).run();
+
+  return jsonResponse({ success: true }, 200, env);
+}
+
+// ── POST /room/state ────────────────────────────────────────────────────────
+// 读取完整 game_state + revision
+export async function handleGetGameState(request: Request, env: Env): Promise<Response> {
+  const body = (await request.json()) as { roomCode?: string };
+  if (!body.roomCode) {
+    return jsonResponse({ error: 'roomCode required' }, 400, env);
+  }
+
+  const row = await env.DB.prepare('SELECT game_state, state_revision FROM rooms WHERE code = ?')
+    .bind(body.roomCode)
+    .first<{ game_state: string | null; state_revision: number }>();
+
+  if (!row?.game_state) {
+    return jsonResponse({ state: null }, 200, env);
+  }
+
+  return jsonResponse(
+    {
+      state: JSON.parse(row.game_state),
+      revision: row.state_revision,
+    },
+    200,
+    env,
+  );
+}
+
+// ── POST /room/revision ─────────────────────────────────────────────────────
+// 轻量级：只读 revision 数字
+export async function handleGetRevision(request: Request, env: Env): Promise<Response> {
+  const body = (await request.json()) as { roomCode?: string };
+  if (!body.roomCode) {
+    return jsonResponse({ error: 'roomCode required' }, 400, env);
+  }
+
+  const row = await env.DB.prepare('SELECT state_revision FROM rooms WHERE code = ?')
+    .bind(body.roomCode)
+    .first<{ state_revision: number }>();
+
+  return jsonResponse({ revision: row?.state_revision ?? null }, 200, env);
+}
+
+// ── POST /room/upsert-state ─────────────────────────────────────────────────
+// 客户端 fire-and-forget 持久化 state
+export async function handleUpsertGameState(request: Request, env: Env): Promise<Response> {
+  const body = (await request.json()) as {
+    roomCode?: string;
+    state?: unknown;
+    revision?: number;
+  };
+  if (!body.roomCode || !body.state || body.revision == null) {
+    return jsonResponse({ error: 'roomCode, state, revision required' }, 400, env);
+  }
+
+  await env.DB.prepare(
+    `UPDATE rooms SET game_state = ?, state_revision = ?, updated_at = datetime('now')
+     WHERE code = ?`,
+  )
+    .bind(JSON.stringify(body.state), body.revision, body.roomCode)
+    .run();
+
+  return jsonResponse({ success: true }, 200, env);
+}

--- a/packages/api-worker/src/handlers/roomHandlers.ts
+++ b/packages/api-worker/src/handlers/roomHandlers.ts
@@ -32,7 +32,6 @@ export async function handleCreateRoom(request: Request, env: Env): Promise<Resp
     sql =
       'INSERT INTO rooms (id, code, host_id, game_state, state_revision) VALUES (?, ?, ?, ?, 1)';
     params.push(JSON.stringify(body.initialState));
-    params.push('1');
   }
 
   try {

--- a/packages/api-worker/src/handlers/shared.ts
+++ b/packages/api-worker/src/handlers/shared.ts
@@ -1,0 +1,94 @@
+/**
+ * handlers/shared — 通用工具函数（Workers 版）
+ *
+ * 与 Edge Functions 的 shared.ts 逻辑一致。
+ * `createSimpleHandler` 接受 `D1Database` 参数。
+ */
+
+import type {
+  HandlerContext,
+  HandlerResult,
+  SideEffect,
+} from '@werewolf/game-engine/engine/handlers/types';
+import type { StateAction } from '@werewolf/game-engine/engine/reducer/types';
+import type { AudioEffect } from '@werewolf/game-engine/protocol/types';
+import type { GameState } from '@werewolf/game-engine/protocol/types';
+
+import type { Env } from '../env';
+import { broadcastIfNeeded } from '../lib/broadcast';
+import { jsonResponse } from '../lib/cors';
+import { processGameAction } from '../lib/gameStateManager';
+
+/** A route handler that receives the original Request + Env and returns a Response. */
+export type HandlerFn = (req: Request, env: Env) => Promise<Response>;
+
+/** Respond with 400 MISSING_PARAMS */
+export function missingParams(env: Env): Response {
+  return jsonResponse({ success: false, reason: 'MISSING_PARAMS' }, 400, env);
+}
+
+/** Validate that a value is a valid seat number (finite non-negative integer). */
+export function isValidSeat(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+/** HTTP 状态码映射 */
+export function resultToStatus(result: { success: boolean; reason?: string }): number {
+  if (result.success) return 200;
+  return result.reason === 'INTERNAL_ERROR' ? 500 : 400;
+}
+
+/** Find seat number by UID */
+function findSeatByUid(state: GameState, uid: string): number | null {
+  for (const [seatKey, player] of Object.entries(state.players)) {
+    if (player?.uid === uid) return Number(seatKey);
+  }
+  return null;
+}
+
+/** Build HandlerContext for game-engine pure handler functions */
+export function buildHandlerContext(state: GameState, uid: string): HandlerContext {
+  return {
+    state,
+    myUid: uid,
+    mySeat: findSeatByUid(state, uid),
+  };
+}
+
+/** Extract PLAY_AUDIO side effects into AudioEffect state actions. */
+export function extractAudioActions(sideEffects: readonly SideEffect[] | undefined): StateAction[] {
+  const audioEffects: AudioEffect[] = (sideEffects ?? [])
+    .filter(
+      (e): e is { type: 'PLAY_AUDIO'; audioKey: string; isEndAudio?: boolean } =>
+        e.type === 'PLAY_AUDIO',
+    )
+    .map((e) => ({ audioKey: e.audioKey, isEndAudio: e.isEndAudio }));
+
+  if (audioEffects.length === 0) return [];
+
+  return [
+    { type: 'SET_PENDING_AUDIO_EFFECTS', payload: { effects: audioEffects } },
+    { type: 'SET_AUDIO_PLAYING', payload: { isPlaying: true } },
+  ];
+}
+
+/**
+ * Factory for simple handlers that only need roomCode.
+ */
+export function createSimpleHandler<I extends { type: string }>(
+  handlerFn: (intent: I, ctx: HandlerContext) => HandlerResult,
+  intent: I,
+): HandlerFn {
+  return async (req: Request, env: Env) => {
+    const body = (await req.json()) as { roomCode?: string };
+    const { roomCode } = body;
+    if (!roomCode) return missingParams(env);
+
+    const result = await processGameAction(env.DB, roomCode, (state: GameState) => {
+      const handlerCtx = buildHandlerContext(state, state.hostUid);
+      return handlerFn(intent, handlerCtx);
+    });
+    broadcastIfNeeded(env, roomCode, result);
+    return jsonResponse(result, resultToStatus(result), env);
+  };
+}

--- a/packages/api-worker/src/index.ts
+++ b/packages/api-worker/src/index.ts
@@ -1,0 +1,229 @@
+/**
+ * Werewolf API Worker — Main entry point
+ *
+ * 统一 HTTP 路由分派，与 Edge Functions 的 game/index.ts 路由一致。
+ * 新增 /auth/* 路由和 /gemini-proxy。
+ *
+ * 路由结构：
+ *   POST /auth/anonymous          — 匿名登录
+ *   POST /auth/signup             — 邮箱注册
+ *   POST /auth/signin             — 邮箱登录
+ *   GET  /auth/user               — 获取当前用户
+ *   PUT  /auth/profile            — 更新资料
+ *   POST /auth/signout            — 登出
+ *   POST /game/{assign,seat,...}  — 游戏控制 API
+ *   POST /game/night/{action,...} — 夜晚流程 API
+ *   POST /gemini-proxy            — Gemini AI 代理
+ *   GET  /health                  — 健康检查
+ */
+
+import type { Env } from './env';
+import { corsPreflightResponse, jsonResponse } from './lib/cors';
+
+// Re-export Durable Object class for wrangler
+export { GameRoom } from './durableObjects/GameRoom';
+
+// Auth handlers
+import {
+  handleAnonymousSignIn,
+  handleGetUser,
+  handleSignIn,
+  handleSignOut,
+  handleSignUp,
+  handleUpdateProfile as handleAuthUpdateProfile,
+} from './handlers/authHandlers';
+// Avatar handlers
+import { handleAvatarServe, handleAvatarUpload } from './handlers/avatarUpload';
+// Game control handlers
+import {
+  handleAssign,
+  handleClearSeats,
+  handleFillBots,
+  handleMarkBotsViewed,
+  handleRestart,
+  handleSeat,
+  handleSetAnimation,
+  handleShareReview,
+  handleStart,
+  handleUpdateProfileRoute,
+  handleUpdateTemplateRoute,
+  handleViewRole,
+} from './handlers/gameControl';
+// Gemini proxy
+import { handleGeminiProxy } from './handlers/geminiProxy';
+// Night handlers
+import {
+  handleAction,
+  handleAudioAck,
+  handleAudioGate,
+  handleEnd,
+  handleGroupConfirmAck,
+  handleMarkBotsGroupConfirmed,
+  handleProgression,
+  handleRevealAck,
+  handleWolfRobotViewed,
+} from './handlers/night';
+// Room handlers
+import {
+  handleCreateRoom,
+  handleDeleteRoom,
+  handleGetGameState,
+  handleGetRevision,
+  handleGetRoom,
+  handleUpsertGameState,
+} from './handlers/roomHandlers';
+import type { HandlerFn } from './handlers/shared';
+
+// ── Route maps ──────────────────────────────────────────────────────────────
+
+const GAME_ROUTES: Record<string, HandlerFn> = {
+  assign: handleAssign,
+  'clear-seats': handleClearSeats,
+  'fill-bots': handleFillBots,
+  'mark-bots-viewed': handleMarkBotsViewed,
+  restart: handleRestart,
+  seat: handleSeat,
+  'set-animation': handleSetAnimation,
+  'share-review': handleShareReview,
+  start: handleStart,
+  'update-profile': handleUpdateProfileRoute,
+  'update-template': handleUpdateTemplateRoute,
+  'view-role': handleViewRole,
+};
+
+const NIGHT_ROUTES: Record<string, HandlerFn> = {
+  action: handleAction,
+  'audio-ack': handleAudioAck,
+  'audio-gate': handleAudioGate,
+  end: handleEnd,
+  'group-confirm-ack': handleGroupConfirmAck,
+  'mark-bots-group-confirmed': handleMarkBotsGroupConfirmed,
+  progression: handleProgression,
+  'reveal-ack': handleRevealAck,
+  'wolf-robot-viewed': handleWolfRobotViewed,
+};
+
+// ── Worker entry ────────────────────────────────────────────────────────────
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    // CORS preflight
+    if (request.method === 'OPTIONS') {
+      return corsPreflightResponse(env);
+    }
+
+    const url = new URL(request.url);
+    const segments = url.pathname.split('/').filter(Boolean);
+
+    try {
+      // /health
+      if (segments[0] === 'health') {
+        return jsonResponse({ status: 'ok' }, 200, env);
+      }
+
+      // /ws?roomCode=XXXX&userId=YYY — WebSocket upgrade → Durable Object
+      if (segments[0] === 'ws') {
+        const roomCode = url.searchParams.get('roomCode');
+        if (!roomCode) {
+          return jsonResponse({ error: 'roomCode required' }, 400, env);
+        }
+        const id = env.GAME_ROOM.idFromName(roomCode);
+        const stub = env.GAME_ROOM.get(id);
+        // Forward the upgrade request to the DO
+        const doUrl = new URL(request.url);
+        doUrl.pathname = '/websocket';
+        return stub.fetch(new Request(doUrl.toString(), request));
+      }
+
+      // /auth/*
+      if (segments[0] === 'auth') {
+        const route = segments[1];
+        if (request.method === 'POST') {
+          switch (route) {
+            case 'anonymous':
+              return handleAnonymousSignIn(request, env);
+            case 'signup':
+              return handleSignUp(request, env);
+            case 'signin':
+              return handleSignIn(request, env);
+            case 'signout':
+              return handleSignOut(request, env);
+          }
+        }
+        if (request.method === 'GET' && route === 'user') {
+          return handleGetUser(request, env);
+        }
+        if (request.method === 'PUT' && route === 'profile') {
+          return handleAuthUpdateProfile(request, env);
+        }
+        return jsonResponse({ error: 'not found' }, 404, env);
+      }
+
+      // /room/*
+      if (segments[0] === 'room' && request.method === 'POST') {
+        switch (segments[1]) {
+          case 'create':
+            return handleCreateRoom(request, env);
+          case 'get':
+            return handleGetRoom(request, env);
+          case 'delete':
+            return handleDeleteRoom(request, env);
+          case 'state':
+            return handleGetGameState(request, env);
+          case 'revision':
+            return handleGetRevision(request, env);
+          case 'upsert-state':
+            return handleUpsertGameState(request, env);
+        }
+        return jsonResponse({ error: 'not found' }, 404, env);
+      }
+
+      // /game/* and /game/night/*
+      if (segments[0] === 'game') {
+        if (request.method !== 'POST') {
+          return jsonResponse({ error: 'method not allowed' }, 405, env);
+        }
+
+        // /game/night/{handler}
+        if (segments[1] === 'night' && segments[2]) {
+          const handler = NIGHT_ROUTES[segments[2]];
+          if (handler) return handler(request, env);
+          return jsonResponse({ error: 'not found' }, 404, env);
+        }
+
+        // /game/{handler}
+        if (segments[1]) {
+          const handler = GAME_ROUTES[segments[1]];
+          if (handler) return handler(request, env);
+          return jsonResponse({ error: 'not found' }, 404, env);
+        }
+
+        return jsonResponse({ error: 'not found' }, 404, env);
+      }
+
+      // /gemini-proxy
+      if (segments[0] === 'gemini-proxy') {
+        if (request.method !== 'POST') {
+          return jsonResponse({ error: 'method not allowed' }, 405, env);
+        }
+        return handleGeminiProxy(request, env);
+      }
+
+      // /avatar/upload (POST) — R2 头像上传
+      if (segments[0] === 'avatar' && segments[1] === 'upload' && request.method === 'POST') {
+        return handleAvatarUpload(request, env);
+      }
+
+      // /avatar/:userId/:filename (GET) — R2 头像提供
+      if (segments[0] === 'avatar' && segments.length >= 3 && request.method === 'GET') {
+        const key = segments.slice(1).join('/');
+        return handleAvatarServe(request, env, key);
+      }
+
+      return jsonResponse({ error: 'not found' }, 404, env);
+    } catch (err) {
+      console.error('[worker] Unhandled error:', err);
+      return jsonResponse({ success: false, reason: 'INTERNAL_ERROR' }, 500, env);
+    }
+  },
+};

--- a/packages/api-worker/src/lib/auth.ts
+++ b/packages/api-worker/src/lib/auth.ts
@@ -1,0 +1,68 @@
+/**
+ * JWT Auth — 自实现轻量级 JWT 认证
+ *
+ * 使用 jose 库签发和验证 JWT。
+ * 覆盖匿名登录和邮箱认证两种场景。
+ * 不依赖第三方 auth 服务。
+ */
+
+import { jwtVerify, SignJWT } from 'jose';
+
+import type { Env } from '../env';
+
+/** JWT payload 中包含的用户信息 */
+export interface JwtPayload {
+  /** User ID */
+  sub: string;
+  /** Is anonymous user */
+  anon?: boolean;
+  /** Email (if authenticated) */
+  email?: string;
+  /** Issued at (seconds) */
+  iat: number;
+  /** Expiration (seconds) */
+  exp: number;
+}
+
+const JWT_ALGORITHM = 'HS256' as const;
+/** Token expiry: 30 days (matches Supabase default session) */
+const TOKEN_EXPIRY_SECONDS = 30 * 24 * 60 * 60;
+
+function getSecret(env: Env): Uint8Array {
+  return new TextEncoder().encode(env.JWT_SECRET);
+}
+
+/** 签发 JWT */
+export async function signToken(
+  userId: string,
+  env: Env,
+  claims?: { anon?: boolean; email?: string },
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT({
+    sub: userId,
+    anon: claims?.anon,
+    email: claims?.email,
+    iat: now,
+    exp: now + TOKEN_EXPIRY_SECONDS,
+  })
+    .setProtectedHeader({ alg: JWT_ALGORITHM })
+    .sign(getSecret(env));
+}
+
+/** 验证 JWT，返回 payload 或 null */
+export async function verifyToken(token: string, env: Env): Promise<JwtPayload | null> {
+  try {
+    const { payload } = await jwtVerify(token, getSecret(env));
+    return payload as unknown as JwtPayload;
+  } catch {
+    return null;
+  }
+}
+
+/** 从 Authorization header 提取 Bearer token */
+export function extractBearerToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  if (!auth?.startsWith('Bearer ')) return null;
+  return auth.slice(7);
+}

--- a/packages/api-worker/src/lib/broadcast.ts
+++ b/packages/api-worker/src/lib/broadcast.ts
@@ -1,0 +1,42 @@
+/**
+ * broadcast — Durable Object 广播辅助
+ *
+ * 在 processGameAction 成功写入 D1 后，将新 state 推送给 DO，
+ * 由 DO 分发到所有该房间的 WebSocket 客户端。
+ * Fire-and-forget — 广播失败不阻塞 API 响应。
+ */
+
+import type { Env } from '../env';
+import type { GameActionResult } from './gameStateManager';
+
+/**
+ * 若 result 包含有效 state + revision，通过 DO 广播给所有 WebSocket 客户端。
+ * 同时检查 sideEffects 中是否包含 BROADCAST_STATE（仅有 BROADCAST_STATE 的 result 才广播）。
+ */
+export function broadcastIfNeeded(env: Env, roomCode: string, result: GameActionResult): void {
+  if (!result.success || !result.state || result.revision == null) return;
+
+  // Check for BROADCAST_STATE side effect
+  const shouldBroadcast = result.sideEffects?.some((e) => e.type === 'BROADCAST_STATE') ?? true;
+
+  if (!shouldBroadcast) return;
+
+  // Fire-and-forget: don't await
+  const id = env.GAME_ROOM.idFromName(roomCode);
+  const stub = env.GAME_ROOM.get(id);
+  stub
+    .fetch(
+      new Request('https://do/broadcast', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          state: result.state,
+          revision: result.revision,
+          roomCode,
+        }),
+      }),
+    )
+    .catch((err) => {
+      console.error('[broadcast] DO broadcast failed:', err);
+    });
+}

--- a/packages/api-worker/src/lib/cors.ts
+++ b/packages/api-worker/src/lib/cors.ts
@@ -1,0 +1,33 @@
+/**
+ * CORS + JSON response helpers
+ *
+ * 与 Edge Functions 的 cors.ts 逻辑一致：
+ * Access-Control-Allow-Origin 从 env.CORS_ORIGIN 读取（默认 '*'）。
+ */
+
+import type { Env } from '../env';
+
+export function corsHeaders(env: Env): Record<string, string> {
+  return {
+    'Access-Control-Allow-Origin': env.CORS_ORIGIN ?? '*',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-region, x-request-id',
+  };
+}
+
+export function jsonResponse(body: unknown, status: number, env: Env): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      ...corsHeaders(env),
+    },
+  });
+}
+
+export function corsPreflightResponse(env: Env): Response {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders(env),
+  });
+}

--- a/packages/api-worker/src/lib/gameStateManager.ts
+++ b/packages/api-worker/src/lib/gameStateManager.ts
@@ -1,0 +1,150 @@
+/**
+ * Game State Manager — D1 版"读-算-写"流程
+ *
+ * 与 Edge Functions 的 gameStateManager.ts 逻辑完全一致：
+ * 1. 从 D1 读 game_state + state_revision
+ * 2. 调用 game-engine 纯函数处理 intent → ProcessResult
+ * 3. 用 gameReducer 将 actions apply 到 state
+ * 4. （可选）内联推进：runInlineProgression 循环
+ * 5. 用 state_revision 做乐观锁写回 D1
+ *
+ * 使用 D1 prepared statements 替代 PostgREST HTTP API。
+ */
+
+import type { SideEffect } from '@werewolf/game-engine/engine/handlers/types';
+import { runInlineProgression } from '@werewolf/game-engine/engine/inlineProgression';
+import { gameReducer } from '@werewolf/game-engine/engine/reducer/gameReducer';
+import type { StateAction } from '@werewolf/game-engine/engine/reducer/types';
+import { normalizeState } from '@werewolf/game-engine/engine/state/normalize';
+import type { GameState } from '@werewolf/game-engine/protocol/types';
+
+/** processGameAction 回调的返回值 */
+export interface ProcessResult {
+  success: boolean;
+  reason?: string;
+  actions: StateAction[];
+  sideEffects?: readonly SideEffect[];
+}
+
+/** processGameAction 的最终返回值 */
+export interface GameActionResult {
+  success: boolean;
+  reason?: string;
+  state?: GameState;
+  revision?: number;
+  sideEffects?: readonly SideEffect[];
+}
+
+interface InlineProgressionOptions {
+  enabled: boolean;
+  nowMs?: number;
+}
+
+/**
+ * 通用的"读-算-写"流程（D1 版）。
+ *
+ * @param db D1Database binding
+ * @param roomCode 4 位房间号
+ * @param process 接收当前 state 和 revision，返回 handler 计算结果
+ * @param inlineProgression 可选的内联推进选项
+ */
+export async function processGameAction(
+  db: D1Database,
+  roomCode: string,
+  process: (state: GameState, revision: number) => ProcessResult,
+  inlineProgression?: InlineProgressionOptions,
+): Promise<GameActionResult> {
+  try {
+    const MAX_RETRIES = 3;
+
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+      // Step 1: 读 D1
+      const row = await db
+        .prepare('SELECT game_state, state_revision FROM rooms WHERE code = ?')
+        .bind(roomCode)
+        .first<{ game_state: string; state_revision: number }>();
+
+      if (!row?.game_state) {
+        return { success: false, reason: 'ROOM_NOT_FOUND' };
+      }
+
+      const currentState: GameState = JSON.parse(row.game_state);
+      const currentRevision = row.state_revision ?? 0;
+
+      // Step 2: 调用 game-engine 纯函数
+      const result = process(currentState, currentRevision);
+
+      if (!result.success) {
+        if (!result.actions || result.actions.length === 0) {
+          return { success: false, reason: result.reason };
+        }
+      }
+
+      // Step 3: apply actions → 新 state
+      let newState = currentState;
+      let totalActionsApplied = 0;
+      for (const action of result.actions) {
+        newState = gameReducer(newState, action);
+        totalActionsApplied++;
+      }
+
+      // Step 3.5: 内联推进（可选）
+      if (inlineProgression?.enabled) {
+        const progressionResult = runInlineProgression(
+          newState,
+          newState.hostUid,
+          inlineProgression.nowMs,
+        );
+        for (const action of progressionResult.actions) {
+          newState = gameReducer(newState, action);
+          totalActionsApplied++;
+        }
+      }
+
+      // No-op guard
+      if (totalActionsApplied === 0) {
+        return {
+          success: result.success,
+          reason: result.reason,
+          state: currentState,
+          revision: currentRevision,
+        };
+      }
+
+      newState = normalizeState(newState);
+
+      // Step 4: 乐观锁写回 D1
+      const writeResult = await db
+        .prepare(
+          `UPDATE rooms
+           SET game_state = ?, state_revision = ?, updated_at = datetime('now')
+           WHERE code = ? AND state_revision = ?`,
+        )
+        .bind(JSON.stringify(newState), currentRevision + 1, roomCode, currentRevision)
+        .run();
+
+      if (!writeResult.meta.changes || writeResult.meta.changes === 0) {
+        // 乐观锁冲突 → 重试
+        if (attempt < MAX_RETRIES) {
+          await new Promise((r) => setTimeout(r, 50 * attempt));
+          continue;
+        }
+        return { success: false, reason: 'CONFLICT_RETRY' };
+      }
+
+      return {
+        success: result.success,
+        reason: result.reason,
+        state: newState,
+        revision: currentRevision + 1,
+        sideEffects: result.sideEffects,
+      };
+    }
+
+    return { success: false, reason: 'CONFLICT_RETRY' };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[processGameAction] Unhandled error:', message, err);
+    return { success: false, reason: 'INTERNAL_ERROR' };
+  }
+}

--- a/packages/api-worker/src/lib/password.ts
+++ b/packages/api-worker/src/lib/password.ts
@@ -1,13 +1,30 @@
 /**
- * Password Hashing — Web Crypto API (PBKDF2)
+ * Password Hashing — 双算法验证 (PBKDF2 + bcrypt)
  *
- * 使用 PBKDF2-SHA256 做密码哈希，CF Workers 运行时原生支持。
- * 不需要 bcrypt/scrypt 等 WASM 依赖。
+ * 新注册用户使用 PBKDF2-SHA256（CF Workers 原生 Web Crypto API）。
+ * 从 Supabase Auth 迁移的用户保留 bcrypt hash，首次登录验证成功后
+ * 自动 rehash 为 PBKDF2（lazy migration）。
  */
+
+import { compare } from 'bcryptjs';
 
 const ITERATIONS = 100_000;
 const SALT_BYTES = 16;
 const HASH_BYTES = 32;
+
+/** 密码验证结果，携带 rehash 信号供调用方更新 DB */
+export interface VerifyResult {
+  valid: boolean;
+  /** 如果为 true，调用方应将 newHash 写回 DB 替换旧的 bcrypt hash */
+  needsRehash: boolean;
+  /** 仅当 needsRehash=true 时有值 — PBKDF2 格式的新 hash */
+  newHash?: string;
+}
+
+/** 检测是否为 bcrypt 格式 hash（$2a$ / $2b$ / $2y$） */
+function isBcryptHash(hash: string): boolean {
+  return /^\$2[aby]\$/.test(hash);
+}
 
 /** 生成 PBKDF2 hash，返回 `$pbkdf2-sha256$iterations$salt$hash` 格式 */
 export async function hashPassword(password: string): Promise<string> {
@@ -34,11 +51,26 @@ export async function hashPassword(password: string): Promise<string> {
   return `$pbkdf2-sha256$${ITERATIONS}$${saltB64}$${hashB64}`;
 }
 
-/** 验证密码是否匹配存储的 hash */
-export async function verifyPassword(password: string, storedHash: string): Promise<boolean> {
+/**
+ * 验证密码，支持 PBKDF2 和 bcrypt 两种格式。
+ * bcrypt 验证成功时标记 needsRehash，由调用方完成 lazy migration。
+ */
+export async function verifyPassword(password: string, storedHash: string): Promise<VerifyResult> {
+  // ── bcrypt (migrated from Supabase Auth) ─────────────────────────────────
+  if (isBcryptHash(storedHash)) {
+    const valid = await compare(password, storedHash);
+    if (!valid) return { valid: false, needsRehash: false };
+    // Rehash to PBKDF2 for future logins
+    const newHash = await hashPassword(password);
+    return { valid: true, needsRehash: true, newHash };
+  }
+
+  // ── PBKDF2-SHA256 (native) ──────────────────────────────────────────────
   const parts = storedHash.split('$');
   // Format: $pbkdf2-sha256$iterations$salt$hash
-  if (parts.length !== 5 || parts[1] !== 'pbkdf2-sha256') return false;
+  if (parts.length !== 5 || parts[1] !== 'pbkdf2-sha256') {
+    return { valid: false, needsRehash: false };
+  }
 
   const iterations = parseInt(parts[2], 10);
   const salt = Uint8Array.from(atob(parts[3]), (c) => c.charCodeAt(0));
@@ -64,10 +96,12 @@ export async function verifyPassword(password: string, storedHash: string): Prom
   const computedHash = btoa(String.fromCharCode(...new Uint8Array(derived)));
 
   // Constant-time comparison to prevent timing attacks
-  if (expectedHash.length !== computedHash.length) return false;
+  if (expectedHash.length !== computedHash.length) {
+    return { valid: false, needsRehash: false };
+  }
   let mismatch = 0;
   for (let i = 0; i < expectedHash.length; i++) {
     mismatch |= expectedHash.charCodeAt(i) ^ computedHash.charCodeAt(i);
   }
-  return mismatch === 0;
+  return { valid: mismatch === 0, needsRehash: false };
 }

--- a/packages/api-worker/src/lib/password.ts
+++ b/packages/api-worker/src/lib/password.ts
@@ -1,0 +1,73 @@
+/**
+ * Password Hashing — Web Crypto API (PBKDF2)
+ *
+ * 使用 PBKDF2-SHA256 做密码哈希，CF Workers 运行时原生支持。
+ * 不需要 bcrypt/scrypt 等 WASM 依赖。
+ */
+
+const ITERATIONS = 100_000;
+const SALT_BYTES = 16;
+const HASH_BYTES = 32;
+
+/** 生成 PBKDF2 hash，返回 `$pbkdf2-sha256$iterations$salt$hash` 格式 */
+export async function hashPassword(password: string): Promise<string> {
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES));
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(password),
+    'PBKDF2',
+    false,
+    ['deriveBits'],
+  );
+  const derived = await crypto.subtle.deriveBits(
+    {
+      name: 'PBKDF2',
+      hash: 'SHA-256',
+      salt,
+      iterations: ITERATIONS,
+    },
+    key,
+    HASH_BYTES * 8,
+  );
+  const saltB64 = btoa(String.fromCharCode(...salt));
+  const hashB64 = btoa(String.fromCharCode(...new Uint8Array(derived)));
+  return `$pbkdf2-sha256$${ITERATIONS}$${saltB64}$${hashB64}`;
+}
+
+/** 验证密码是否匹配存储的 hash */
+export async function verifyPassword(password: string, storedHash: string): Promise<boolean> {
+  const parts = storedHash.split('$');
+  // Format: $pbkdf2-sha256$iterations$salt$hash
+  if (parts.length !== 5 || parts[1] !== 'pbkdf2-sha256') return false;
+
+  const iterations = parseInt(parts[2], 10);
+  const salt = Uint8Array.from(atob(parts[3]), (c) => c.charCodeAt(0));
+  const expectedHash = parts[4];
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(password),
+    'PBKDF2',
+    false,
+    ['deriveBits'],
+  );
+  const derived = await crypto.subtle.deriveBits(
+    {
+      name: 'PBKDF2',
+      hash: 'SHA-256',
+      salt,
+      iterations,
+    },
+    key,
+    HASH_BYTES * 8,
+  );
+  const computedHash = btoa(String.fromCharCode(...new Uint8Array(derived)));
+
+  // Constant-time comparison to prevent timing attacks
+  if (expectedHash.length !== computedHash.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < expectedHash.length; i++) {
+    mismatch |= expectedHash.charCodeAt(i) ^ computedHash.charCodeAt(i);
+  }
+  return mismatch === 0;
+}

--- a/packages/api-worker/src/worker-globals.d.ts
+++ b/packages/api-worker/src/worker-globals.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Worker globals supplementary declarations
+ *
+ * game-engine 源码通过 globalThis.crypto 访问 Web Crypto API。
+ * @cloudflare/workers-types 已声明顶层 crypto 变量，
+ * 但 ES2022 lib 的 globalThis 上不包含 crypto 属性。
+ * 此文件在 globalThis 上补充 crypto 声明以消除类型错误。
+ */
+
+interface Crypto {
+  getRandomValues<T extends ArrayBufferView>(array: T): T;
+  randomUUID(): string;
+  readonly subtle: SubtleCrypto;
+}
+
+// Augment globalThis so `globalThis.crypto` resolves
+declare let crypto: Crypto;

--- a/packages/api-worker/tsconfig.json
+++ b/packages/api-worker/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "@werewolf/game-engine/*": ["../game-engine/src/*"],
+      "@werewolf/game-engine": ["../game-engine/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/api-worker/wrangler.toml
+++ b/packages/api-worker/wrangler.toml
@@ -8,12 +8,13 @@ compatibility_flags = ["nodejs_compat"]
 [[d1_databases]]
 binding = "DB"
 database_name = "werewolf-db"
-database_id = "placeholder-replace-after-create"
+database_id = "f6ddfa17-8a27-442c-b6c0-6abf56f06a43"
 
 # ── R2 Bucket (Phase 3: avatar storage) ─────────────────────────────────────
-[[r2_buckets]]
-binding = "AVATARS"
-bucket_name = "werewolf-avatars"
+# Uncomment after enabling R2 in CF Dashboard:
+# [[r2_buckets]]
+# binding = "AVATARS"
+# bucket_name = "werewolf-avatars"
 
 # ── Durable Objects (Phase 2: realtime) ──────────────────────────────────────
 [durable_objects]

--- a/packages/api-worker/wrangler.toml
+++ b/packages/api-worker/wrangler.toml
@@ -11,10 +11,9 @@ database_name = "werewolf-db"
 database_id = "f6ddfa17-8a27-442c-b6c0-6abf56f06a43"
 
 # ── R2 Bucket (Phase 3: avatar storage) ─────────────────────────────────────
-# Uncomment after enabling R2 in CF Dashboard:
-# [[r2_buckets]]
-# binding = "AVATARS"
-# bucket_name = "werewolf-avatars"
+[[r2_buckets]]
+binding = "AVATARS"
+bucket_name = "werewolf-avatars"
 
 # ── Durable Objects (Phase 2: realtime) ──────────────────────────────────────
 [durable_objects]

--- a/packages/api-worker/wrangler.toml
+++ b/packages/api-worker/wrangler.toml
@@ -1,0 +1,35 @@
+#:schema ./node_modules/wrangler/config-schema.json
+name = "werewolf-api"
+main = "src/index.ts"
+compatibility_date = "2025-04-01"
+compatibility_flags = ["nodejs_compat"]
+
+# ── D1 Database ──────────────────────────────────────────────────────────────
+[[d1_databases]]
+binding = "DB"
+database_name = "werewolf-db"
+database_id = "placeholder-replace-after-create"
+
+# ── R2 Bucket (Phase 3: avatar storage) ─────────────────────────────────────
+[[r2_buckets]]
+binding = "AVATARS"
+bucket_name = "werewolf-avatars"
+
+# ── Durable Objects (Phase 2: realtime) ──────────────────────────────────────
+[durable_objects]
+bindings = [
+  { name = "GAME_ROOM", class_name = "GameRoom" }
+]
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["GameRoom"]
+
+# ── Environment Variables ────────────────────────────────────────────────────
+[vars]
+ENVIRONMENT = "production"
+CORS_ORIGIN = "*"
+
+# ── Development Overrides ────────────────────────────────────────────────────
+[env.dev]
+vars = { ENVIRONMENT = "development", CORS_ORIGIN = "*" }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       '@werewolf/game-engine':
         specifier: workspace:*
         version: link:../game-engine
+      bcryptjs:
+        specifier: ^3.0.3
+        version: 3.0.3
       jose:
         specifier: ^6.0.11
         version: 6.2.2
@@ -2332,6 +2335,10 @@ packages:
 
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
+    hasBin: true
+
+  bcryptjs@3.0.3:
+    resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
     hasBin: true
 
   better-opn@3.0.2:
@@ -8075,6 +8082,8 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.9.19: {}
+
+  bcryptjs@3.0.3: {}
 
   better-opn@3.0.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,22 @@ importers:
         specifier: ^8.57.1
         version: 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
 
+  packages/api-worker:
+    dependencies:
+      '@werewolf/game-engine':
+        specifier: workspace:*
+        version: link:../game-engine
+      jose:
+        specifier: ^6.0.11
+        version: 6.2.2
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260401.0
+        version: 4.20260403.1
+      wrangler:
+        specifier: ^4.14.0
+        version: 4.80.0(@cloudflare/workers-types@4.20260403.1)
+
   packages/game-engine:
     devDependencies:
       esbuild:
@@ -718,6 +734,52 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
+  '@cloudflare/kv-asset-handler@0.4.2':
+    resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.0':
+    resolution: {integrity: sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260401.1':
+    resolution: {integrity: sha512-ZSmceM70jH6k+/62VkEcmMNzrpr4kSctkX5Lsgqv38KktfhPY/hsh75y1lRoPWS3H3kgMa4p2pUSlidZR1u2hw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260401.1':
+    resolution: {integrity: sha512-7UKWF+IUZ3NXMVPsDg8Cjg0r58b+uYlfvs5Yt8bvtU+geCtW4P2MxRHmRSEo8SryckXOJjb/b8tcncgCykFu8g==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260401.1':
+    resolution: {integrity: sha512-MDWUH/0bvL/l9aauN8zEddyYOXId1OueqrUCXXENNJ95R/lSmF6OgGVuXaYhoIhxQkNiEJ/0NOlnVYj9mJq4dw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260401.1':
+    resolution: {integrity: sha512-UgkzpMzVWM/bwbo3vjCTg2aoKfGcUhiEoQoDdo6RGWvbHRJyLVZ4VQCG9ZcISiztkiS2ICCoYOtPy6M/lV6Gcw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260401.1':
+    resolution: {integrity: sha512-HBLzcQF5iF4Qv20tQ++pG7xs3OsCnaIbc+GAi6fmhUKZhvmzvml/jwrQzLJ+MPm0cQo41K5OO/U3T4S8tvJetQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@4.20260403.1':
+    resolution: {integrity: sha512-p6oSNt3yUwcxSoXZ7qCog7+kgQbkSx1Beoci7TMb/xbRF05VR0cO/p1XUE2SLHZ7IgSIc3tNMpFKa0L0fa3Lzg==}
+
   '@commitlint/cli@20.5.0':
     resolution: {integrity: sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ==}
     engines: {node: '>=v18'}
@@ -799,9 +861,22 @@ packages:
       conventional-commits-parser:
         optional: true
 
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@egjs/hammerjs@2.0.17':
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
     engines: {node: '>=0.8.0'}
+
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
 
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
@@ -809,10 +884,22 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.4':
     resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.4':
@@ -821,16 +908,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.4':
     resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.4':
     resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.4':
@@ -839,10 +944,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.4':
     resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.4':
@@ -851,10 +968,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.4':
     resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.4':
@@ -863,10 +992,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.4':
     resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.4':
@@ -875,10 +1016,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.4':
     resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.4':
@@ -887,10 +1040,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.4':
     resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.4':
@@ -899,16 +1064,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.4':
     resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.4':
     resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.4':
@@ -917,10 +1100,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.4':
     resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.4':
@@ -929,11 +1124,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.4':
     resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.4':
     resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
@@ -941,16 +1148,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.4':
     resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.4':
     resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.4':
@@ -1167,6 +1392,159 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
   '@isaacs/ttlcache@1.4.1':
     resolution: {integrity: sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==}
     engines: {node: '>=12'}
@@ -1280,10 +1658,22 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
   '@playwright/test@1.58.2':
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
   '@react-native-async-storage/async-storage@2.2.0':
     resolution: {integrity: sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==}
@@ -1522,11 +1912,18 @@ packages:
   '@sinclair/typebox@0.34.48':
     resolution: {integrity: sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==}
 
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+
+  '@speed-highlight/core@1.2.15':
+    resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
   '@supabase/auth-js@2.101.1':
     resolution: {integrity: sha512-Kd0Wey+RkFHgyVep7adS6UOE2pN6MJ3mZ32PAXSvfw6IjUkFRC7IQpdZZjUOcUe5pXr1ejufCRgF6lsGINe4Tw==}
@@ -1945,6 +2342,9 @@ packages:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
 
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -2166,6 +2566,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   core-js-compat@3.48.0:
     resolution: {integrity: sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==}
@@ -2414,6 +2818,9 @@ packages:
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
@@ -2448,6 +2855,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
@@ -3423,6 +3835,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3480,6 +3895,10 @@ packages:
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
   lan-network@0.2.0:
@@ -3785,6 +4204,11 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  miniflare@4.20260401.0:
+    resolution: {integrity: sha512-lngHPzZFN9sxYG/mhzvnWiBMNVAN5MsO/7g32ttJ07rymtiK/ZBalODTKb8Od+BQdlU5DOR4CjVt9NydjnUyYg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   minimatch@10.2.3:
     resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
     engines: {node: 18 || 20 || >=22}
@@ -4008,6 +4432,12 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -4427,6 +4857,10 @@ packages:
     resolution: {integrity: sha512-TPbeg0b7ylrswdGCji8FRGFAKuqbpQlLbL8SOle3j1iHSs5Ob5mhvMAxWN2UItOjgALAB5Zp3fmMfj8mbWvXKw==}
     engines: {node: '>=10'}
 
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -4644,6 +5078,10 @@ packages:
   styleq@0.1.3:
     resolution: {integrity: sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA==}
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -4823,6 +5261,13 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
+  undici@7.24.4:
+    resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
+    engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -4968,6 +5413,21 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
+  workerd@1.20260401.1:
+    resolution: {integrity: sha512-mUYCd+ohaWJWF5nhDzxugWaAD/DM8Dw0ze3B7bu8JaA7S70+XQJXcvcvwE8C4qGcxSdCyqjsrFzqxKubECDwzg==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.80.0:
+    resolution: {integrity: sha512-2ZKF7uPeOZy65BGk3YfvqBCPo/xH1MrAlMmH9mVP+tCNBrTUMnwOHSj1HrZHgR8LttkAqhko0fGz+I4ax1rzyQ==}
+    engines: {node: '>=20.3.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260401.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -4993,6 +5453,18 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -5068,6 +5540,12 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -5728,6 +6206,31 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@cloudflare/kv-asset-handler@0.4.2': {}
+
+  '@cloudflare/unenv-preset@2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260401.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260401.1
+
+  '@cloudflare/workerd-darwin-64@1.20260401.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260401.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260401.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260401.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260401.1':
+    optional: true
+
+  '@cloudflare/workers-types@4.20260403.1': {}
+
   '@commitlint/cli@20.5.0(@types/node@25.2.3)(conventional-commits-parser@6.3.0)(typescript@5.9.3)':
     dependencies:
       '@commitlint/format': 20.5.0
@@ -5850,83 +6353,170 @@ snapshots:
     optionalDependencies:
       conventional-commits-parser: 6.3.0
 
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@egjs/hammerjs@2.0.17':
     dependencies:
       '@types/hammerjs': 2.0.46
 
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
     optional: true
 
   '@esbuild/android-arm64@0.27.4':
     optional: true
 
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
   '@esbuild/android-arm@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
     optional: true
 
   '@esbuild/android-x64@0.27.4':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
     optional: true
 
   '@esbuild/darwin-x64@0.27.4':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
     optional: true
 
   '@esbuild/linux-arm@0.27.4':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
     optional: true
 
   '@esbuild/linux-loong64@0.27.4':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.4':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
     optional: true
 
   '@esbuild/linux-s390x@0.27.4':
     optional: true
 
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
   '@esbuild/linux-x64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.4':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.4':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.4':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
     optional: true
 
   '@esbuild/win32-arm64@0.27.4':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
     optional: true
 
   '@esbuild/win32-x64@0.27.4':
@@ -6314,6 +6904,102 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.9.2
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
   '@isaacs/ttlcache@1.4.1': {}
 
   '@istanbuljs/load-nyc-config@1.1.0':
@@ -6524,9 +7210,26 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   '@playwright/test@1.58.2':
     dependencies:
       playwright: 1.58.2
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
 
   '@react-native-async-storage/async-storage@2.2.0(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))':
     dependencies:
@@ -6829,6 +7532,8 @@ snapshots:
 
   '@sinclair/typebox@0.34.48': {}
 
+  '@sindresorhus/is@7.2.0': {}
+
   '@sinonjs/commons@3.0.1':
     dependencies:
       type-detect: 4.0.8
@@ -6836,6 +7541,8 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@speed-highlight/core@1.2.15': {}
 
   '@supabase/auth-js@2.101.1':
     dependencies:
@@ -7375,6 +8082,8 @@ snapshots:
 
   big-integer@1.6.52: {}
 
+  blake3-wasm@2.1.5: {}
+
   boolbase@1.0.0: {}
 
   bplist-creator@0.1.0:
@@ -7613,6 +8322,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.1.1: {}
+
   core-js-compat@3.48.0:
     dependencies:
       browserslist: 4.28.1
@@ -7837,6 +8548,8 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  error-stack-parser-es@1.0.5: {}
+
   error-stack-parser@2.1.4:
     dependencies:
       stackframe: 1.3.4
@@ -7941,6 +8654,35 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -9237,6 +9979,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.2.2: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -9309,6 +10053,8 @@ snapshots:
       json-buffer: 3.0.1
 
   kleur@3.0.3: {}
+
+  kleur@4.1.5: {}
 
   lan-network@0.2.0: {}
 
@@ -9681,6 +10427,18 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  miniflare@4.20260401.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.4
+      workerd: 1.20260401.1
+      ws: 8.18.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.2.3:
     dependencies:
       brace-expansion: 5.0.3
@@ -9894,6 +10652,10 @@ snapshots:
     dependencies:
       lru-cache: 11.2.6
       minipass: 7.1.3
+
+  path-to-regexp@6.3.0: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -10379,6 +11141,37 @@ snapshots:
 
   sf-symbols-typescript@2.2.0: {}
 
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -10611,6 +11404,8 @@ snapshots:
 
   styleq@0.1.3: {}
 
+  supports-color@10.2.2: {}
+
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -10786,6 +11581,12 @@ snapshots:
 
   undici-types@7.16.0: {}
 
+  undici@7.24.4: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
+
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -10933,6 +11734,31 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
+  workerd@1.20260401.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260401.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260401.1
+      '@cloudflare/workerd-linux-64': 1.20260401.1
+      '@cloudflare/workerd-linux-arm64': 1.20260401.1
+      '@cloudflare/workerd-windows-64': 1.20260401.1
+
+  wrangler@4.80.0(@cloudflare/workers-types@4.20260403.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.2
+      '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260401.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260401.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260401.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260403.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -10959,6 +11785,8 @@ snapshots:
       signal-exit: 3.0.7
 
   ws@7.5.10: {}
+
+  ws@8.18.0: {}
 
   ws@8.19.0: {}
 
@@ -11020,6 +11848,19 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.15
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:

--- a/scripts/migrate-supabase-to-cf.mjs
+++ b/scripts/migrate-supabase-to-cf.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+/**
+ * Supabase → Cloudflare 一次性用户 + 头像迁移脚本
+ *
+ * 功能：
+ *   1. 从 Supabase Auth 导出注册用户（非匿名），连同 bcrypt hash
+ *   2. 写入 CF D1 users 表（幂等：email 已存在则 skip）
+ *   3. 从 Supabase Storage 下载自定义头像 → 上传到 CF R2
+ *   4. 更新 D1 users 表的 avatar URL 指向 R2
+ *
+ * 前置条件：
+ *   - SUPABASE_URL             Supabase 项目 URL
+ *   - SUPABASE_SERVICE_ROLE_KEY Supabase service_role key（Admin API）
+ *   - CF_API_URL               CF Worker URL（如 https://werewolf-api.xxx.workers.dev）
+ *   - CF_D1_DATABASE_ID        D1 database ID
+ *   - CF_ACCOUNT_ID            Cloudflare Account ID
+ *   - CF_API_TOKEN             Cloudflare API Token（D1 + R2 权限）
+ *   - CF_R2_BUCKET             R2 bucket name（默认 werewolf-avatars）
+ *
+ * 用法：
+ *   node scripts/migrate-supabase-to-cf.mjs
+ *
+ * 幂等安全：可重复运行，已迁移的用户/头像会被跳过。
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SUPABASE_URL = requireEnv('SUPABASE_URL');
+const SUPABASE_SERVICE_ROLE_KEY = requireEnv('SUPABASE_SERVICE_ROLE_KEY');
+const CF_ACCOUNT_ID = requireEnv('CF_ACCOUNT_ID');
+const CF_API_TOKEN = requireEnv('CF_API_TOKEN');
+const CF_D1_DATABASE_ID = requireEnv('CF_D1_DATABASE_ID');
+const CF_R2_BUCKET = process.env.CF_R2_BUCKET || 'werewolf-avatars';
+const CF_API_URL = process.env.CF_API_URL; // optional, for avatar URL rewriting
+
+function requireEnv(name) {
+  const val = process.env[name];
+  if (!val) {
+    console.error(`❌ Missing required env: ${name}`);
+    process.exit(1);
+  }
+  return val;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Supabase Admin API helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function supabaseAdminFetch(path, options = {}) {
+  const res = await fetch(`${SUPABASE_URL}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+      apikey: SUPABASE_SERVICE_ROLE_KEY,
+      ...options.headers,
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Supabase ${path} failed (${res.status}): ${body}`);
+  }
+  return res.json();
+}
+
+/** 分页获取所有注册用户（非匿名） */
+async function listRegisteredUsers() {
+  const users = [];
+  let page = 1;
+  const perPage = 50;
+
+  while (true) {
+    const data = await supabaseAdminFetch(
+      `/auth/v1/admin/users?page=${page}&per_page=${perPage}`,
+    );
+    const pageUsers = data.users || data;
+    if (!Array.isArray(pageUsers) || pageUsers.length === 0) break;
+
+    for (const u of pageUsers) {
+      // 跳过匿名用户
+      if (u.is_anonymous || !u.email) continue;
+      users.push(u);
+    }
+    if (pageUsers.length < perPage) break;
+    page++;
+  }
+  return users;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cloudflare D1 API helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function d1Query(sql, params = []) {
+  const res = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/d1/database/${CF_D1_DATABASE_ID}/query`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${CF_API_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ sql, params }),
+    },
+  );
+  const json = await res.json();
+  if (!json.success) {
+    throw new Error(`D1 query failed: ${JSON.stringify(json.errors)}`);
+  }
+  return json.result;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cloudflare R2 API helpers (S3-compatible via CF API)
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function r2Upload(key, buffer, contentType) {
+  const res = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/r2/buckets/${CF_R2_BUCKET}/objects/${encodeURIComponent(key)}`,
+    {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${CF_API_TOKEN}`,
+        'Content-Type': contentType,
+      },
+      body: buffer,
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`R2 upload failed for ${key}: ${res.status} ${text}`);
+  }
+}
+
+async function r2ObjectExists(key) {
+  const res = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/r2/buckets/${CF_R2_BUCKET}/objects/${encodeURIComponent(key)}`,
+    {
+      method: 'HEAD',
+      headers: { Authorization: `Bearer ${CF_API_TOKEN}` },
+    },
+  );
+  return res.ok;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Migration: Users
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function migrateUsers(users) {
+  console.log(`\n📦 Migrating ${users.length} registered user(s) to D1...\n`);
+  let migrated = 0;
+  let skipped = 0;
+
+  for (const u of users) {
+    // Check if already exists in D1
+    const existing = await d1Query('SELECT id FROM users WHERE email = ?', [u.email]);
+    if (existing[0]?.results?.length > 0) {
+      console.log(`  ⏭  ${u.email} — already exists, skipping`);
+      skipped++;
+      continue;
+    }
+
+    const meta = u.user_metadata || {};
+    // Supabase stores bcrypt hash in encrypted_password field (Admin API)
+    const passwordHash = u.encrypted_password || null;
+
+    await d1Query(
+      `INSERT INTO users (id, email, password_hash, display_name, avatar_url, custom_avatar_url, avatar_frame, is_anonymous)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 0)`,
+      [
+        u.id,
+        u.email,
+        passwordHash,
+        meta.display_name || u.email.split('@')[0],
+        meta.avatar_url || null,
+        meta.custom_avatar_url || null,
+        meta.avatar_frame || null,
+      ],
+    );
+    console.log(`  ✅ ${u.email} (${u.id})`);
+    migrated++;
+  }
+
+  console.log(`\n  Users: ${migrated} migrated, ${skipped} skipped\n`);
+  return migrated;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Migration: Avatars
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function migrateAvatars(users) {
+  // Collect users with custom avatars from Supabase Storage
+  const usersWithAvatars = users.filter((u) => {
+    const url = u.user_metadata?.custom_avatar_url;
+    return url && url.includes('supabase');
+  });
+
+  if (usersWithAvatars.length === 0) {
+    console.log('📷 No custom avatars to migrate.\n');
+    return;
+  }
+
+  console.log(`📷 Migrating ${usersWithAvatars.length} avatar(s) to R2...\n`);
+  let migrated = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const u of usersWithAvatars) {
+    const avatarUrl = u.user_metadata.custom_avatar_url;
+    // Extract storage path from Supabase URL:
+    // https://xxx.supabase.co/storage/v1/object/public/avatars/{userId}/{file}
+    const match = avatarUrl.match(/\/avatars\/(.+)$/);
+    if (!match) {
+      console.log(`  ⚠️  ${u.email} — cannot parse avatar URL: ${avatarUrl}`);
+      failed++;
+      continue;
+    }
+
+    const r2Key = match[1]; // {userId}/{file}
+
+    // Check if already in R2
+    const exists = await r2ObjectExists(r2Key);
+    if (exists) {
+      console.log(`  ⏭  ${u.email} — avatar already in R2, skipping`);
+      skipped++;
+      continue;
+    }
+
+    // Download from Supabase Storage (public URL)
+    try {
+      const res = await fetch(avatarUrl);
+      if (!res.ok) {
+        console.log(`  ⚠️  ${u.email} — download failed (${res.status})`);
+        failed++;
+        continue;
+      }
+      const buffer = await res.arrayBuffer();
+      const contentType = res.headers.get('content-type') || 'image/jpeg';
+
+      // Upload to R2
+      await r2Upload(r2Key, buffer, contentType);
+
+      // Update D1 with new R2 URL
+      const newUrl = CF_API_URL
+        ? `${CF_API_URL}/avatar/${r2Key}`
+        : `https://werewolf-avatars.${CF_ACCOUNT_ID}.r2.dev/${r2Key}`;
+
+      await d1Query(
+        `UPDATE users SET avatar_url = ?, custom_avatar_url = ?, updated_at = datetime('now') WHERE id = ?`,
+        [newUrl, newUrl, u.id],
+      );
+
+      console.log(`  ✅ ${u.email} → ${r2Key}`);
+      migrated++;
+    } catch (err) {
+      console.log(`  ⚠️  ${u.email} — error: ${err.message}`);
+      failed++;
+    }
+  }
+
+  console.log(`\n  Avatars: ${migrated} migrated, ${skipped} skipped, ${failed} failed\n`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log('🔄 Supabase → Cloudflare Migration\n');
+  console.log(`  Supabase: ${SUPABASE_URL}`);
+  console.log(`  CF D1:    ${CF_D1_DATABASE_ID}`);
+  console.log(`  CF R2:    ${CF_R2_BUCKET}\n`);
+
+  // Step 1: List registered users from Supabase
+  console.log('📋 Fetching registered users from Supabase Auth...');
+  const users = await listRegisteredUsers();
+  console.log(`  Found ${users.length} registered user(s)\n`);
+
+  if (users.length === 0) {
+    console.log('✨ No registered users to migrate. Done!');
+    return;
+  }
+
+  // Step 2: Migrate users to D1
+  await migrateUsers(users);
+
+  // Step 3: Migrate avatars to R2
+  await migrateAvatars(users);
+
+  console.log('✨ Migration complete!');
+}
+
+main().catch((err) => {
+  console.error('❌ Migration failed:', err);
+  process.exit(1);
+});

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -22,9 +22,11 @@ const CF_API_URL = process.env.EXPO_PUBLIC_CF_API_URL ?? 'https://werewolf-api.o
 
 /**
  * API base URL — 根据后端选择自动切换
+ *
+ * BACKEND=cloudflare 时只认 EXPO_PUBLIC_CF_API_URL；
+ * BACKEND=supabase 时认 EXPO_PUBLIC_API_URL（向后兼容）。
  */
-export const API_BASE_URL: string =
-  process.env.EXPO_PUBLIC_API_URL ?? (BACKEND === 'cloudflare' ? CF_API_URL : SUPABASE_API_URL);
+export const API_BASE_URL: string = BACKEND === 'cloudflare' ? CF_API_URL : SUPABASE_API_URL;
 
 /**
  * Edge Function 区域路由 header 值。

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,19 +1,30 @@
 /**
  * api - API base URL 配置
  *
- * 提供 Supabase Edge Functions 的 base URL，导出 API_BASE_URL。
- * 生产环境指向 Supabase Edge Functions，开发环境可通过环境变量覆盖。
+ * 根据 EXPO_PUBLIC_BACKEND 环境变量选择 Supabase Edge Functions 或 Cloudflare Workers。
  * 纯配置模块，不包含业务逻辑或副作用。
  */
 
+type BackendType = 'supabase' | 'cloudflare';
+const BACKEND: BackendType =
+  (process.env.EXPO_PUBLIC_BACKEND as BackendType | undefined) ?? 'supabase';
+
 /**
- * API base URL
- *
- * - 生产环境（Supabase Edge Functions）：`https://<project-ref>.supabase.co/functions/v1`
- * - 开发环境：可通过 EXPO_PUBLIC_API_URL 覆盖（如 `http://localhost:54321/functions/v1`）
+ * Supabase Edge Functions base URL
+ */
+const SUPABASE_API_URL =
+  process.env.EXPO_PUBLIC_API_URL ?? 'https://abmzjezdvpzyeooqhhsn.supabase.co/functions/v1';
+
+/**
+ * Cloudflare Workers base URL
+ */
+const CF_API_URL = process.env.EXPO_PUBLIC_CF_API_URL ?? 'https://werewolf-api.eyan.workers.dev';
+
+/**
+ * API base URL — 根据后端选择自动切换
  */
 export const API_BASE_URL: string =
-  process.env.EXPO_PUBLIC_API_URL ?? 'https://abmzjezdvpzyeooqhhsn.supabase.co/functions/v1';
+  process.env.EXPO_PUBLIC_API_URL ?? (BACKEND === 'cloudflare' ? CF_API_URL : SUPABASE_API_URL);
 
 /**
  * Edge Function 区域路由 header 值。

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -18,7 +18,7 @@ const SUPABASE_API_URL =
 /**
  * Cloudflare Workers base URL
  */
-const CF_API_URL = process.env.EXPO_PUBLIC_CF_API_URL ?? 'https://werewolf-api.eyan.workers.dev';
+const CF_API_URL = process.env.EXPO_PUBLIC_CF_API_URL ?? 'https://werewolf-api.olveryu.workers.dev';
 
 /**
  * API base URL — 根据后端选择自动切换

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -10,12 +10,12 @@
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Sentry from '@sentry/react-native';
-import type { User as SupabaseUser } from '@supabase/supabase-js';
 import React, { createContext, use, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { LAST_ROOM_NUMBER_KEY } from '@/config/storageKeys';
 import { useServices } from '@/contexts/ServiceContext';
 import { isSupabaseConfigured, supabase } from '@/services/infra/supabaseClient';
+import type { AuthUser } from '@/services/types/IAuthService';
 import { isAbortError, isNetworkError } from '@/utils/errorUtils';
 import { authLog, isExpectedAuthError, mapAuthError } from '@/utils/logger';
 
@@ -65,17 +65,17 @@ const userEquals = (a: User | null, b: User | null): boolean => {
   );
 };
 
-// Convert Supabase user to our User type
-const toUser = (supabaseUser: SupabaseUser | null): User | null => {
-  if (!supabaseUser) return null;
+// Convert auth user to our User type
+const toUser = (authUser: AuthUser | null): User | null => {
+  if (!authUser) return null;
   return {
-    uid: supabaseUser.id,
-    email: supabaseUser.email || null,
-    displayName: supabaseUser.user_metadata?.display_name || null,
-    avatarUrl: supabaseUser.user_metadata?.avatar_url || null,
-    customAvatarUrl: supabaseUser.user_metadata?.custom_avatar_url || null,
-    avatarFrame: supabaseUser.user_metadata?.avatar_frame || null,
-    isAnonymous: supabaseUser.is_anonymous || false,
+    uid: authUser.id,
+    email: authUser.email || null,
+    displayName: (authUser.user_metadata?.display_name as string) || null,
+    avatarUrl: (authUser.user_metadata?.avatar_url as string) || null,
+    customAvatarUrl: (authUser.user_metadata?.custom_avatar_url as string) || null,
+    avatarFrame: (authUser.user_metadata?.avatar_frame as string) || null,
+    isAnonymous: authUser.is_anonymous || false,
   };
 };
 

--- a/src/contexts/ServiceContext.tsx
+++ b/src/contexts/ServiceContext.tsx
@@ -7,18 +7,18 @@
  */
 import React, { createContext, use, useMemo } from 'react';
 
-import type { AvatarUploadService } from '@/services/feature/AvatarUploadService';
 import type { SettingsService } from '@/services/feature/SettingsService';
 import type { AudioService } from '@/services/infra/AudioService';
-import type { AuthService } from '@/services/infra/AuthService';
-import type { RoomService } from '@/services/infra/RoomService';
+import type { IAuthService } from '@/services/types/IAuthService';
+import type { IRoomService } from '@/services/types/IRoomService';
+import type { IStorageService } from '@/services/types/IStorageService';
 
 export interface ServiceContextValue {
-  authService: AuthService;
-  roomService: RoomService;
+  authService: IAuthService;
+  roomService: IRoomService;
   settingsService: SettingsService;
   audioService: AudioService;
-  avatarUploadService: AvatarUploadService;
+  avatarUploadService: IStorageService;
 }
 
 const ServiceContext = createContext<ServiceContextValue | null>(null);

--- a/src/hooks/useGameRoom.ts
+++ b/src/hooks/useGameRoom.ts
@@ -28,8 +28,8 @@ import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 
 import { useGameFacade } from '@/contexts';
 import { useAuthContext } from '@/contexts/AuthContext';
 import { useServices } from '@/contexts/ServiceContext';
-import type { RoomRecord } from '@/services/infra/RoomService';
 import type { ConnectionStatus, IGameFacade } from '@/services/types/IGameFacade';
+import type { RoomRecord } from '@/services/types/IRoomService';
 import type { LocalGameState } from '@/types/GameStateTypes';
 import { setAlertBlocked, showAlert } from '@/utils/alert';
 import { gameRoomLog } from '@/utils/logger';

--- a/src/hooks/useRoomLifecycle.ts
+++ b/src/hooks/useRoomLifecycle.ts
@@ -18,10 +18,11 @@ import type { GameTemplate } from '@werewolf/game-engine/models/Template';
 import { useCallback, useState } from 'react';
 
 import { LAST_ROOM_NUMBER_KEY } from '@/config/storageKeys';
-import type { AuthService } from '@/services/infra/AuthService';
-import type { RoomRecord, RoomService } from '@/services/infra/RoomService';
+import type { IAuthService } from '@/services/types/IAuthService';
 import type { IGameFacade } from '@/services/types/IGameFacade';
 import { ConnectionStatus } from '@/services/types/IGameFacade';
+import type { IRoomService } from '@/services/types/IRoomService';
+import type { RoomRecord } from '@/services/types/IRoomService';
 import { handleError } from '@/utils/errorPipeline';
 import { getErrorMessage } from '@/utils/errorUtils';
 import { gameRoomLog } from '@/utils/logger';
@@ -61,8 +62,8 @@ interface RoomLifecycleState {
 
 interface RoomLifecycleDeps {
   facade: IGameFacade;
-  authService: AuthService;
-  roomService: RoomService;
+  authService: IAuthService;
+  roomService: IRoomService;
   connection: ConnectionSyncActions;
   setRoomRecord: (record: RoomRecord | null) => void;
 }

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -8,6 +8,7 @@
  */
 import {
   getPathFromState as defaultGetPathFromState,
+  getStateFromPath as defaultGetStateFromPath,
   LinkingOptions,
   NavigationContainer,
 } from '@react-navigation/native';
@@ -69,9 +70,36 @@ const linking: LinkingOptions<RootStackParamList> = {
       },
       Settings: 'settings',
       Encyclopedia: 'encyclopedia',
-      Notepad: 'notepad',
+      Notepad: 'notepad/:roomNumber',
       AvatarPicker: 'avatar-picker',
     },
+  },
+  // Rebuild navigation stack when deep-linking into screens that expect a parent.
+  // e.g. /notepad/ABC123 → [Home, Room({roomNumber: 'ABC123'}), Notepad({roomNumber: 'ABC123'})]
+  getStateFromPath(path, options) {
+    const state = defaultGetStateFromPath(path, options);
+    if (!state) return state;
+
+    const routes = state.routes;
+    const topRoute = routes[routes.length - 1];
+
+    // Notepad requires Room underneath; inject Home + Room when missing
+    if (topRoute?.name === 'Notepad' && routes.length === 1) {
+      const roomNumber = (topRoute.params as { roomNumber?: string })?.roomNumber;
+      if (roomNumber) {
+        return {
+          ...state,
+          routes: [
+            { name: 'Home' as const },
+            { name: 'Room' as const, params: { roomNumber, isHost: false } },
+            topRoute,
+          ],
+          index: 2,
+        };
+      }
+    }
+
+    return state;
   },
   // Strip non-serializable params (template, roleRevealAnimation) from browser URL
   getPathFromState(state, options) {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -20,7 +20,7 @@ export type RootStackParamList = {
   };
   Settings: undefined;
   Encyclopedia: undefined;
-  Notepad: undefined;
+  Notepad: { roomNumber: string };
   AvatarPicker: undefined;
 };
 

--- a/src/screens/ConfigScreen/useConfigScreenState.ts
+++ b/src/screens/ConfigScreen/useConfigScreenState.ts
@@ -23,9 +23,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { LAST_ROOM_NUMBER_KEY } from '@/config/storageKeys';
 import type { RootStackParamList } from '@/navigation/types';
 import type { SettingsService } from '@/services/feature/SettingsService';
-import type { AuthService } from '@/services/infra/AuthService';
-import type { RoomService } from '@/services/infra/RoomService';
+import type { IAuthService } from '@/services/types/IAuthService';
 import type { IGameFacade } from '@/services/types/IGameFacade';
+import type { IRoomService } from '@/services/types/IRoomService';
 import type { ThemeColors } from '@/theme';
 import { showErrorAlert } from '@/utils/alertPresets';
 import { handleError } from '@/utils/errorPipeline';
@@ -53,8 +53,8 @@ interface UseConfigScreenStateParams {
   navigation: ConfigNavigationProp;
   facade: IGameFacade;
   settingsService: SettingsService;
-  authService: AuthService;
-  roomService: RoomService;
+  authService: IAuthService;
+  roomService: IRoomService;
   colors: ThemeColors;
 }
 

--- a/src/screens/NotepadScreen/NotepadScreen.tsx
+++ b/src/screens/NotepadScreen/NotepadScreen.tsx
@@ -8,7 +8,9 @@
  */
 
 import { Ionicons } from '@expo/vector-icons';
-import { useNavigation } from '@react-navigation/native';
+import type { RouteProp } from '@react-navigation/native';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { ROLE_SPECS } from '@werewolf/game-engine/models/roles';
 import React, { useCallback, useMemo } from 'react';
 import { Text, TextInput, TouchableOpacity, View } from 'react-native';
@@ -19,6 +21,7 @@ import { NotepadPanel } from '@/components/NotepadPanel';
 import { UI_ICONS } from '@/config/iconTokens';
 import { useGameFacade } from '@/contexts';
 import { useNotepad } from '@/hooks/useNotepad';
+import { RootStackParamList } from '@/navigation/types';
 import { isAIChatReady } from '@/services/feature/AIChatService';
 import { fixed, typography, useColors } from '@/theme';
 import { requestAIChatMessage } from '@/utils/aiChatBridge';
@@ -31,10 +34,20 @@ import { createNotepadScreenStyles } from './NotepadScreen.styles';
 export const NotepadScreen: React.FC = () => {
   const colors = useColors();
   const styles = useMemo(() => createNotepadScreenStyles(colors), [colors]);
-  const navigation = useNavigation();
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList, 'Notepad'>>();
+  const route = useRoute<RouteProp<RootStackParamList, 'Notepad'>>();
 
   const facade = useGameFacade();
   const notepad = useNotepad(facade);
+
+  const handleGoBack = useCallback(() => {
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+    } else {
+      // Stale Tab reload: stack lost, navigate back to Room with roomNumber from URL
+      navigation.navigate('Room', { roomNumber: route.params.roomNumber, isHost: false });
+    }
+  }, [navigation, route.params.roomNumber]);
 
   const handleAIAnalysis = useCallback(() => {
     if (!isAIChatReady()) {
@@ -155,7 +168,7 @@ export const NotepadScreen: React.FC = () => {
             <Ionicons name={UI_ICONS.DELETE} size={typography.body} style={styles.headerBtnText} />
           </TouchableOpacity>
           <TouchableOpacity
-            onPress={() => navigation.goBack()}
+            onPress={handleGoBack}
             style={styles.headerBtn}
             activeOpacity={fixed.activeOpacity}
           >

--- a/src/screens/RoomScreen/RoomScreen.tsx
+++ b/src/screens/RoomScreen/RoomScreen.tsx
@@ -67,8 +67,8 @@ export const RoomScreen: React.FC<Props> = ({ route, navigation }) => {
 
   // ─── Notepad ──────────────────────────────────────────────────────────
   const handleNotepadPress = useCallback(() => {
-    navigation.navigate('Notepad');
-  }, [navigation]);
+    navigation.navigate('Notepad', { roomNumber: route.params.roomNumber });
+  }, [navigation, route.params.roomNumber]);
 
   // ─── QR Code Modal state ──────────────────────────────────────────────
   const [qrModalVisible, setQrModalVisible] = useState(false);

--- a/src/services/cloudflare/CFAuthService.ts
+++ b/src/services/cloudflare/CFAuthService.ts
@@ -1,0 +1,269 @@
+/**
+ * CFAuthService — Cloudflare Workers JWT 认证服务
+ *
+ * 实现 IAuthService 接口，通过 HTTP 调用 Workers /auth/* 端点。
+ * JWT token 持久化在 AsyncStorage，刷新/恢复 session 靠 GET /auth/user。
+ * 与 Supabase AuthService 行为语义兼容（匿名 + 邮箱升级 + 资料管理）。
+ * 不涉及游戏逻辑或游戏状态存储。
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { getAllRoleIds, getRoleSpec } from '@werewolf/game-engine/models/roles';
+
+import type { AuthUser, GetCurrentUserResponse, IAuthService } from '@/services/types/IAuthService';
+import { handleError } from '@/utils/errorPipeline';
+import { authLog } from '@/utils/logger';
+import { withTimeout } from '@/utils/withTimeout';
+
+import { cfGet, cfPost, cfPut, setTokenProvider } from './cfFetch';
+
+const TOKEN_STORAGE_KEY = 'cf_auth_token';
+
+export class CFAuthService implements IAuthService {
+  #currentUserId: string | null = null;
+  #cachedToken: string | null = null;
+  readonly #initPromise: Promise<void>;
+
+  constructor() {
+    // Register token provider so cfFetch auto-injects Bearer header
+    setTokenProvider(() => this.#cachedToken);
+    this.#initPromise = this.#autoSignIn();
+  }
+
+  async #autoSignIn(): Promise<void> {
+    try {
+      const existingUserId = await this.initAuth();
+      if (existingUserId) {
+        authLog.info('Restored session:', existingUserId);
+      }
+    } catch (error) {
+      handleError(error, { label: 'CFAuth.autoSignIn', logger: authLog, alertTitle: false });
+    }
+  }
+
+  async waitForInit(): Promise<void> {
+    await withTimeout(this.#initPromise, 10000, () => new Error('登录超时，请重试'));
+  }
+
+  async ensureAuthenticated(): Promise<string> {
+    if (this.#currentUserId) return this.#currentUserId;
+    const restored = await this.initAuth();
+    if (restored) return restored;
+    return this.signInAnonymously();
+  }
+
+  isConfigured(): boolean {
+    // CF backend is always configured if this service was instantiated
+    return true;
+  }
+
+  getCurrentUserId(): string | null {
+    return this.#currentUserId;
+  }
+
+  getCurrentUser(): Promise<GetCurrentUserResponse> | null {
+    if (!this.#cachedToken) return null;
+    return cfGet<GetCurrentUserResponse>('/auth/user');
+  }
+
+  async signInAnonymously(): Promise<string> {
+    const data = await cfPost<{
+      access_token: string;
+      user: { id: string; is_anonymous: boolean };
+    }>('/auth/anonymous');
+
+    await this.#saveToken(data.access_token);
+    this.#currentUserId = data.user.id;
+    return data.user.id;
+  }
+
+  async signUpWithEmail(
+    email: string,
+    password: string,
+    displayName?: string,
+  ): Promise<{ userId: string; user: AuthUser | null }> {
+    const data = await cfPost<{
+      access_token: string;
+      user: AuthUser;
+    }>('/auth/signup', { email, password, displayName });
+
+    await this.#saveToken(data.access_token);
+    this.#currentUserId = data.user.id;
+    return { userId: data.user.id, user: data.user };
+  }
+
+  async signInWithEmail(email: string, password: string): Promise<string> {
+    const data = await cfPost<{
+      access_token: string;
+      user: { id: string };
+    }>('/auth/signin', { email, password });
+
+    await this.#saveToken(data.access_token);
+    this.#currentUserId = data.user.id;
+    return data.user.id;
+  }
+
+  async updateProfile(updates: {
+    displayName?: string;
+    avatarUrl?: string;
+    customAvatarUrl?: string;
+    avatarFrame?: string;
+  }): Promise<void> {
+    await cfPut('/auth/profile', updates);
+  }
+
+  async signOut(): Promise<void> {
+    await cfPost('/auth/signout');
+    await this.#clearToken();
+    this.#currentUserId = null;
+  }
+
+  async initAuth(): Promise<string | null> {
+    const token = await AsyncStorage.getItem(TOKEN_STORAGE_KEY);
+    if (!token) return null;
+
+    this.#cachedToken = token;
+    // Verify token is still valid by calling /auth/user
+    try {
+      const resp = await cfGet<GetCurrentUserResponse>('/auth/user');
+      if (resp.data.user) {
+        this.#currentUserId = resp.data.user.id;
+        return this.#currentUserId;
+      }
+    } catch {
+      authLog.debug('initAuth: token invalid or expired, clearing');
+    }
+
+    await this.#clearToken();
+    return null;
+  }
+
+  generateDisplayName(uid: string): string {
+    const adjectives = [
+      '快乐',
+      '勇敢',
+      '聪明',
+      '神秘',
+      '可爱',
+      '酷炫',
+      '狡猾',
+      '正义',
+      '机智',
+      '沉稳',
+      '热血',
+      '冷静',
+      '傲娇',
+      '呆萌',
+      '腹黑',
+      '高冷',
+      '温柔',
+      '霸气',
+      '淡定',
+      '暴躁',
+      '憨厚',
+      '精明',
+      '天真',
+      '老练',
+      '迷糊',
+      '清醒',
+      '困倦',
+      '亢奋',
+      '悠闲',
+      '忙碌',
+      '饥饿',
+      '满足',
+      '微醺',
+      '元气',
+      '慵懒',
+      '活泼',
+      '安静',
+      '躁动',
+      '专注',
+      '发呆',
+      '优雅',
+      '野性',
+      '文艺',
+      '朋克',
+      '复古',
+      '未来',
+      '古典',
+      '摇滚',
+      '甜美',
+      '辛辣',
+      '清新',
+      '浓郁',
+      '梦幻',
+      '现实',
+      '浪漫',
+      '理性',
+      '超级',
+      '无敌',
+      '绝世',
+      '传说',
+      '史诗',
+      '究极',
+      '至尊',
+      '王者',
+    ];
+    const nouns = getAllRoleIds().map((id) => getRoleSpec(id).displayName);
+
+    const chars = uid.split('');
+    const hash1 = chars.reduce((acc, char, i) => acc + (char.codePointAt(0) || 0) * (i + 1), 0);
+    const hash3 = chars.reduce((acc, char) => acc ^ (char.codePointAt(0) || 0), 0) * 31;
+
+    const idx1 = Math.abs(hash1) % adjectives.length;
+    const idx3 = Math.abs(hash3) % nouns.length;
+
+    return adjectives[idx1] + nouns[idx3];
+  }
+
+  async getCurrentDisplayName(): Promise<string> {
+    try {
+      const resp = await this.getCurrentUser();
+      if (resp) {
+        const user = (await resp).data.user;
+        const registeredName = user?.user_metadata?.display_name as string | undefined;
+        if (registeredName) return registeredName;
+      }
+    } catch (e) {
+      authLog.debug('getCurrentDisplayName failed, falling through to generated name', e);
+    }
+    return this.generateDisplayName(this.#currentUserId || 'anonymous');
+  }
+
+  async getCurrentAvatarUrl(): Promise<string | null> {
+    try {
+      const resp = await this.getCurrentUser();
+      if (resp) {
+        const user = (await resp).data.user;
+        return (user?.user_metadata?.avatar_url as string) || null;
+      }
+    } catch (e) {
+      authLog.debug('getCurrentAvatarUrl failed', e);
+    }
+    return null;
+  }
+
+  async getCurrentAvatarFrame(): Promise<string | null> {
+    try {
+      const resp = await this.getCurrentUser();
+      if (resp) {
+        const user = (await resp).data.user;
+        return (user?.user_metadata?.avatar_frame as string) || null;
+      }
+    } catch (e) {
+      authLog.debug('getCurrentAvatarFrame failed', e);
+    }
+    return null;
+  }
+
+  async #saveToken(token: string): Promise<void> {
+    this.#cachedToken = token;
+    await AsyncStorage.setItem(TOKEN_STORAGE_KEY, token);
+  }
+
+  async #clearToken(): Promise<void> {
+    this.#cachedToken = null;
+    await AsyncStorage.removeItem(TOKEN_STORAGE_KEY);
+  }
+}

--- a/src/services/cloudflare/CFRealtimeService.ts
+++ b/src/services/cloudflare/CFRealtimeService.ts
@@ -1,0 +1,291 @@
+/**
+ * CFRealtimeService — Cloudflare Durable Objects WebSocket 实时传输服务
+ *
+ * 实现 IRealtimeService 接口，通过原生 WebSocket 连接到 Workers DO。
+ * DO 推送 STATE_UPDATE 消息，本服务解析后调用 onDbStateChange 回调。
+ *
+ * 简化的重连策略（对比 Supabase 6 层恢复）：
+ * - L1: WebSocket onclose → 自动重连（指数退避，最多 5 次）
+ * - L2: Browser online event → 立即重连
+ * - L3: visibilitychange → visible → 拉取最新 state（由上层 useConnectionSync 处理）
+ * DO WebSocket 已有服务端心跳（ping/pong），无需客户端额外保活。
+ *
+ * 不包含游戏逻辑，不持久化状态。
+ */
+
+import type { GameState } from '@werewolf/game-engine/protocol/types';
+
+import { API_BASE_URL } from '@/config/api';
+import { ConnectionStatus } from '@/services/types/IGameFacade';
+import type { ConnectionStatusListener, IRealtimeService } from '@/services/types/IRealtimeService';
+import { realtimeLog } from '@/utils/logger';
+
+interface JoinRoomParams {
+  roomCode: string;
+  userId: string;
+  onDbStateChange?: (state: GameState, revision: number) => void;
+}
+
+const MAX_RECONNECT_ATTEMPTS = 5;
+const BASE_RECONNECT_DELAY_MS = 1000;
+
+export class CFRealtimeService implements IRealtimeService {
+  #ws: WebSocket | null = null;
+  #connectionStatus: ConnectionStatus = ConnectionStatus.Disconnected;
+  readonly #statusListeners: Set<ConnectionStatusListener> = new Set();
+  #lastJoinParams: JoinRoomParams | null = null;
+  #reconnectAttempt = 0;
+  #reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  #onlineHandler: (() => void) | null = null;
+  #pingInterval: ReturnType<typeof setInterval> | null = null;
+
+  addStatusListener(listener: ConnectionStatusListener): () => void {
+    this.#statusListeners.add(listener);
+    listener(this.#connectionStatus);
+    return () => this.#statusListeners.delete(listener);
+  }
+
+  #setConnectionStatus(status: ConnectionStatus): void {
+    if (this.#connectionStatus !== status) {
+      realtimeLog.info(`Connection status: ${this.#connectionStatus} -> ${status}`);
+      this.#connectionStatus = status;
+      this.#statusListeners.forEach((listener) => listener(status));
+    }
+  }
+
+  async joinRoom(
+    roomCode: string,
+    userId: string,
+    callbacks: {
+      onDbStateChange?: (state: GameState, revision: number) => void;
+    },
+  ): Promise<void> {
+    // Leave previous room
+    await this.leaveRoom();
+
+    this.#setConnectionStatus(ConnectionStatus.Connecting);
+
+    this.#lastJoinParams = {
+      roomCode,
+      userId,
+      onDbStateChange: callbacks.onDbStateChange,
+    };
+
+    this.#reconnectAttempt = 0;
+    await this.#connect(roomCode, userId, callbacks.onDbStateChange);
+
+    // Register browser online event for reconnection (Web only)
+    this.#registerOnlineHandler();
+  }
+
+  async #connect(
+    roomCode: string,
+    userId: string,
+    onDbStateChange?: (state: GameState, revision: number) => void,
+  ): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      // Build WebSocket URL: replace http(s) with ws(s)
+      const wsBase = API_BASE_URL.replace(/^http/, 'ws');
+      const wsUrl = `${wsBase}/ws?roomCode=${encodeURIComponent(roomCode)}&userId=${encodeURIComponent(userId)}`;
+
+      const ws = new WebSocket(wsUrl);
+      let resolved = false;
+
+      const timeout = setTimeout(() => {
+        if (!resolved) {
+          resolved = true;
+          ws.close();
+          this.#setConnectionStatus(ConnectionStatus.Disconnected);
+          reject(new Error('WebSocket connection timeout'));
+        }
+      }, 8000);
+
+      ws.onopen = () => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(timeout);
+        this.#ws = ws;
+        this.#reconnectAttempt = 0;
+        this.#setConnectionStatus(ConnectionStatus.Syncing);
+        this.#startPing();
+        realtimeLog.info('WebSocket connected to room:', roomCode);
+        resolve();
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data as string);
+          if (data.type === 'STATE_UPDATE' && data.state && data.revision != null) {
+            realtimeLog.debug('WS state update, revision:', data.revision);
+            onDbStateChange?.(data.state as GameState, data.revision as number);
+          }
+          // pong messages are handled silently
+        } catch {
+          realtimeLog.warn('Failed to parse WS message');
+        }
+      };
+
+      ws.onclose = () => {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timeout);
+          this.#setConnectionStatus(ConnectionStatus.Disconnected);
+          reject(new Error('WebSocket closed before open'));
+          return;
+        }
+
+        this.#stopPing();
+        this.#ws = null;
+
+        // Only auto-reconnect if we have cached params (not intentionally left)
+        if (this.#lastJoinParams) {
+          this.#setConnectionStatus(ConnectionStatus.Disconnected);
+          this.#scheduleReconnect();
+        }
+      };
+
+      ws.onerror = () => {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timeout);
+          this.#setConnectionStatus(ConnectionStatus.Disconnected);
+          reject(new Error('WebSocket connection error'));
+        }
+        // After open, errors are handled by onclose
+      };
+    });
+  }
+
+  #scheduleReconnect(): void {
+    if (!this.#lastJoinParams) return;
+    if (this.#reconnectAttempt >= MAX_RECONNECT_ATTEMPTS) {
+      realtimeLog.warn('Max reconnect attempts reached');
+      return;
+    }
+
+    const delay = BASE_RECONNECT_DELAY_MS * Math.pow(2, this.#reconnectAttempt);
+    this.#reconnectAttempt++;
+
+    realtimeLog.info(
+      `Reconnecting in ${delay}ms (attempt ${this.#reconnectAttempt}/${MAX_RECONNECT_ATTEMPTS})`,
+    );
+
+    this.#reconnectTimer = setTimeout(() => {
+      if (!this.#lastJoinParams) return;
+      const { roomCode, userId, onDbStateChange } = this.#lastJoinParams;
+      this.#setConnectionStatus(ConnectionStatus.Connecting);
+      this.#connect(roomCode, userId, onDbStateChange).catch((err) => {
+        realtimeLog.warn('Reconnect failed:', err instanceof Error ? err.message : err);
+        this.#scheduleReconnect();
+      });
+    }, delay);
+  }
+
+  #registerOnlineHandler(): void {
+    if (typeof globalThis.window?.addEventListener !== 'function') return;
+
+    this.#onlineHandler = () => {
+      if (!this.#lastJoinParams) return;
+      if (this.#connectionStatus === ConnectionStatus.Live) return;
+
+      realtimeLog.info('Browser online event — triggering reconnect');
+      // Clear any pending reconnect timer
+      if (this.#reconnectTimer) {
+        clearTimeout(this.#reconnectTimer);
+        this.#reconnectTimer = null;
+      }
+      this.#reconnectAttempt = 0;
+      const { roomCode, userId, onDbStateChange } = this.#lastJoinParams;
+      this.#setConnectionStatus(ConnectionStatus.Connecting);
+      this.#connect(roomCode, userId, onDbStateChange).catch((err) => {
+        realtimeLog.warn(
+          'Online-triggered reconnect failed:',
+          err instanceof Error ? err.message : err,
+        );
+        this.#scheduleReconnect();
+      });
+    };
+
+    globalThis.window.addEventListener('online', this.#onlineHandler);
+  }
+
+  #unregisterOnlineHandler(): void {
+    if (this.#onlineHandler && typeof globalThis.window?.removeEventListener === 'function') {
+      globalThis.window.removeEventListener('online', this.#onlineHandler);
+      this.#onlineHandler = null;
+    }
+  }
+
+  #startPing(): void {
+    this.#stopPing();
+    // Send ping every 30s to keep connection alive
+    this.#pingInterval = setInterval(() => {
+      if (this.#ws?.readyState === WebSocket.OPEN) {
+        this.#ws.send(JSON.stringify({ type: 'ping' }));
+      }
+    }, 30_000);
+  }
+
+  #stopPing(): void {
+    if (this.#pingInterval) {
+      clearInterval(this.#pingInterval);
+      this.#pingInterval = null;
+    }
+  }
+
+  markAsLive(): void {
+    if (this.#connectionStatus === ConnectionStatus.Syncing) {
+      this.#setConnectionStatus(ConnectionStatus.Live);
+    }
+  }
+
+  async rejoinCurrentRoom(): Promise<void> {
+    if (
+      this.#connectionStatus === ConnectionStatus.Connecting ||
+      this.#connectionStatus === ConnectionStatus.Syncing
+    ) {
+      realtimeLog.info('rejoinCurrentRoom: skipped (already in progress)');
+      return;
+    }
+
+    if (!this.#lastJoinParams) {
+      throw new Error('CFRealtimeService: cannot rejoin — no cached params');
+    }
+
+    const { roomCode, userId, onDbStateChange } = this.#lastJoinParams;
+    realtimeLog.info('Dead channel recovery: rejoinCurrentRoom', { roomCode });
+
+    // Close existing WS
+    this.#closeWebSocket();
+
+    this.#reconnectAttempt = 0;
+    this.#setConnectionStatus(ConnectionStatus.Connecting);
+    await this.#connect(roomCode, userId, onDbStateChange);
+  }
+
+  async leaveRoom(): Promise<void> {
+    // Clear reconnect
+    if (this.#reconnectTimer) {
+      clearTimeout(this.#reconnectTimer);
+      this.#reconnectTimer = null;
+    }
+    this.#unregisterOnlineHandler();
+    this.#closeWebSocket();
+    this.#lastJoinParams = null;
+    this.#setConnectionStatus(ConnectionStatus.Disconnected);
+    realtimeLog.info('Left room');
+  }
+
+  #closeWebSocket(): void {
+    this.#stopPing();
+    if (this.#ws) {
+      const ws = this.#ws;
+      this.#ws = null;
+      try {
+        ws.close();
+      } catch {
+        // Ignore close errors
+      }
+    }
+  }
+}

--- a/src/services/cloudflare/CFRoomService.ts
+++ b/src/services/cloudflare/CFRoomService.ts
@@ -1,0 +1,114 @@
+/**
+ * CFRoomService — Cloudflare Workers 房间服务
+ *
+ * 实现 IRoomService 接口，通过 HTTP 调用 Workers /room/* 端点。
+ * 与 Supabase RoomService 行为语义兼容。
+ * 不校验游戏逻辑，不涉及 realtime 传输。
+ */
+
+import type { GameState } from '@werewolf/game-engine/protocol/types';
+
+import type { IRoomService, RoomRecord } from '@/services/types/IRoomService';
+import { roomLog } from '@/utils/logger';
+import { generateRoomCode } from '@/utils/roomCode';
+
+import { cfPost } from './cfFetch';
+
+export class CFRoomService implements IRoomService {
+  async createRoom(
+    hostUid: string,
+    initialRoomNumber?: string,
+    maxRetries: number = 5,
+    buildInitialState?: (roomCode: string) => GameState,
+  ): Promise<RoomRecord> {
+    let lastError: Error | undefined;
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      const roomNumber =
+        attempt === 1 && initialRoomNumber ? initialRoomNumber : generateRoomCode();
+
+      try {
+        const data = await cfPost<{
+          room: { roomNumber: string; hostUid: string; createdAt: string };
+        }>('/room/create', {
+          roomCode: roomNumber,
+          initialState: buildInitialState ? buildInitialState(roomNumber) : undefined,
+        });
+
+        if (attempt > 1) {
+          roomLog.info(`Room created on attempt ${attempt} with code ${roomNumber}`);
+        }
+
+        return {
+          roomNumber: data.room.roomNumber,
+          hostUid: data.room.hostUid,
+          createdAt: new Date(data.room.createdAt),
+        };
+      } catch (err) {
+        const errObj = err as { status?: number; reason?: string };
+        const isConflict = errObj.status === 409;
+
+        if (isConflict && attempt < maxRetries) {
+          roomLog.debug(`Room code ${roomNumber} already exists (attempt ${attempt}), retrying...`);
+          continue;
+        }
+
+        lastError = err instanceof Error ? err : new Error(String(err));
+      }
+    }
+
+    throw lastError || new Error('Failed to create room after max retries');
+  }
+
+  async getRoom(roomNumber: string): Promise<RoomRecord | null> {
+    const data = await cfPost<{
+      room: { roomNumber: string; hostUid: string; createdAt: string } | null;
+    }>('/room/get', { roomCode: roomNumber });
+
+    if (!data.room) return null;
+
+    return {
+      roomNumber: data.room.roomNumber,
+      hostUid: data.room.hostUid,
+      createdAt: new Date(data.room.createdAt),
+    };
+  }
+
+  async roomExists(roomNumber: string): Promise<boolean> {
+    const room = await this.getRoom(roomNumber);
+    return room !== null;
+  }
+
+  async deleteRoom(roomNumber: string): Promise<void> {
+    await cfPost('/room/delete', { roomCode: roomNumber });
+  }
+
+  async upsertGameState(roomCode: string, state: GameState, revision: number): Promise<void> {
+    try {
+      await cfPost('/room/upsert-state', { roomCode, state, revision });
+    } catch (err) {
+      roomLog.warn('upsertGameState failed:', err instanceof Error ? err.message : err);
+    }
+  }
+
+  async getStateRevision(roomCode: string): Promise<number | null> {
+    const data = await cfPost<{ revision: number | null }>('/room/revision', {
+      roomCode,
+    });
+    return data.revision;
+  }
+
+  async getGameState(roomCode: string): Promise<{ state: GameState; revision: number } | null> {
+    const data = await cfPost<{
+      state: GameState | null;
+      revision?: number;
+    }>('/room/state', { roomCode });
+
+    if (!data.state) return null;
+
+    return {
+      state: data.state,
+      revision: data.revision ?? 0,
+    };
+  }
+}

--- a/src/services/cloudflare/CFStorageService.ts
+++ b/src/services/cloudflare/CFStorageService.ts
@@ -1,0 +1,120 @@
+/**
+ * CFStorageService — Cloudflare R2 头像上传服务
+ *
+ * 实现 IStorageService 接口，通过 multipart/form-data 上传到 Workers /avatar/upload。
+ * 与 Supabase AvatarUploadService 行为语义兼容（上传 → 返回公开 URL）。
+ * 压缩在本地端完成（Web DOM Canvas），与 Supabase 版一致。
+ * 不涉及游戏逻辑或认证逻辑。
+ */
+
+import { API_BASE_URL, API_TIMEOUT_MS } from '@/config/api';
+import type { IStorageService } from '@/services/types/IStorageService';
+import { log } from '@/utils/logger';
+import { withTimeout } from '@/utils/withTimeout';
+
+import { getCurrentToken } from './cfFetch';
+
+const avatarLog = log.extend('CFAvatar');
+
+export class CFStorageService implements IStorageService {
+  async uploadAvatar(fileUri: string): Promise<string> {
+    // Compress image before upload (Web only — RN fallback to original)
+    const blob = await this.#prepareImage(fileUri);
+
+    const formData = new FormData();
+    formData.append('file', blob, 'avatar.jpg');
+
+    const token = getCurrentToken();
+    const headers: Record<string, string> = {};
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    const fetchPromise = fetch(`${API_BASE_URL}/avatar/upload`, {
+      method: 'POST',
+      headers,
+      body: formData,
+    });
+
+    const res = await withTimeout(fetchPromise, API_TIMEOUT_MS, () => new Error('上传超时'));
+
+    if (!res.ok) {
+      const contentType = res.headers.get('content-type') ?? '';
+      if (contentType.includes('application/json')) {
+        const body = (await res.json()) as { error?: string };
+        throw new Error(body.error ?? `上传失败 (${res.status})`);
+      }
+      throw new Error(`上传失败 (${res.status})`);
+    }
+
+    const data = (await res.json()) as { url: string };
+    avatarLog.debug('Avatar uploaded:', data.url);
+    return data.url;
+  }
+
+  /**
+   * Prepare image: compress if DOM APIs available (Web), otherwise fetch original (RN native).
+   */
+  async #prepareImage(fileUri: string): Promise<Blob> {
+    if (this.#isDomCompressionAvailable()) {
+      return this.#compressImageWithDom(fileUri, 512, 0.85);
+    }
+    const response = await fetch(fileUri);
+    return response.blob();
+  }
+
+  #isDomCompressionAvailable(): boolean {
+    return (
+      typeof Image !== 'undefined' &&
+      typeof document !== 'undefined' &&
+      typeof document.createElement === 'function'
+    );
+  }
+
+  #compressImageWithDom(fileUri: string, maxSize: number, quality: number): Promise<Blob> {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.crossOrigin = 'anonymous';
+
+      img.onload = () => {
+        let { width, height } = img;
+
+        if (width > height && width > maxSize) {
+          height = (height * maxSize) / width;
+          width = maxSize;
+        } else if (height > maxSize) {
+          width = (width * maxSize) / height;
+          height = maxSize;
+        }
+
+        const canvas = document.createElement('canvas');
+        canvas.width = width;
+        canvas.height = height;
+
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          reject(new Error('图片处理失败，请换一张图片重试'));
+          return;
+        }
+
+        ctx.drawImage(img, 0, 0, width, height);
+
+        canvas.toBlob(
+          (blob) => {
+            if (blob) {
+              avatarLog.debug(`Compressed image: ${Math.round(blob.size / 1024)}KB`);
+              resolve(blob);
+            } else {
+              reject(new Error('图片压缩失败，请换一张图片重试'));
+            }
+          },
+          'image/jpeg',
+          quality,
+        );
+      };
+
+      img.onerror = () => reject(new Error('图片加载失败，请换一张图片重试'));
+      img.src = fileUri;
+    });
+  }
+}

--- a/src/services/cloudflare/cfFetch.ts
+++ b/src/services/cloudflare/cfFetch.ts
@@ -1,0 +1,130 @@
+/**
+ * cfFetch — Cloudflare Workers API HTTP 客户端
+ *
+ * 统一封装 fetch 调用：JWT Bearer token 注入、超时、JSON 响应解析、
+ * 结构化错误处理（非 JSON 响应返回 `{ success: false, reason: 'SERVER_ERROR' }`）。
+ * 纯 IO 模块，不含业务逻辑。
+ */
+
+import { API_BASE_URL, API_TIMEOUT_MS } from '@/config/api';
+import { withTimeout } from '@/utils/withTimeout';
+
+/** 从 AsyncStorage 读取 JWT token 的回调（由 CFAuthService 注入） */
+let tokenProvider: (() => string | null) | null = null;
+
+export function setTokenProvider(provider: () => string | null): void {
+  tokenProvider = provider;
+}
+
+/** 获取当前 JWT token（供 CFStorageService 等非 cfFetch 调用者使用） */
+export function getCurrentToken(): string | null {
+  return tokenProvider?.() ?? null;
+}
+
+/**
+ * 发起 JSON POST 请求到 Workers API。
+ *
+ * - 自动注入 Authorization: Bearer <token>
+ * - 校验 res.ok + content-type 含 application/json
+ * - 超时保护（API_TIMEOUT_MS）
+ */
+export async function cfPost<T = Record<string, unknown>>(
+  path: string,
+  body?: Record<string, unknown>,
+): Promise<T> {
+  const url = `${API_BASE_URL}${path}`;
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+
+  const token = tokenProvider?.();
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const fetchPromise = fetch(url, {
+    method: 'POST',
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const res = await withTimeout(fetchPromise, API_TIMEOUT_MS, () => new Error('请求超时'));
+
+  return parseJsonResponse<T>(res);
+}
+
+/**
+ * 发起 GET 请求到 Workers API。
+ */
+export async function cfGet<T = Record<string, unknown>>(path: string): Promise<T> {
+  const url = `${API_BASE_URL}${path}`;
+  const headers: Record<string, string> = {};
+
+  const token = tokenProvider?.();
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const fetchPromise = fetch(url, { method: 'GET', headers });
+  const res = await withTimeout(fetchPromise, API_TIMEOUT_MS, () => new Error('请求超时'));
+
+  return parseJsonResponse<T>(res);
+}
+
+/**
+ * 发起 PUT 请求到 Workers API。
+ */
+export async function cfPut<T = Record<string, unknown>>(
+  path: string,
+  body?: Record<string, unknown>,
+): Promise<T> {
+  const url = `${API_BASE_URL}${path}`;
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+
+  const token = tokenProvider?.();
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const fetchPromise = fetch(url, {
+    method: 'PUT',
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const res = await withTimeout(fetchPromise, API_TIMEOUT_MS, () => new Error('请求超时'));
+
+  return parseJsonResponse<T>(res);
+}
+
+/**
+ * 安全解析 JSON 响应。非 JSON（502/503 HTML）返回结构化错误。
+ */
+async function parseJsonResponse<T>(res: Response): Promise<T> {
+  const contentType = res.headers.get('content-type') ?? '';
+
+  if (!contentType.includes('application/json')) {
+    if (!res.ok) {
+      throw Object.assign(new Error(`服务端错误 (${res.status})`), {
+        status: res.status,
+        reason: 'SERVER_ERROR',
+      });
+    }
+    // 200 but not JSON — unusual
+    throw Object.assign(new Error('响应格式异常'), { reason: 'SERVER_ERROR' });
+  }
+
+  const data = (await res.json()) as T;
+
+  if (!res.ok) {
+    const errBody = data as Record<string, unknown>;
+    throw Object.assign(
+      new Error((errBody.error as string) ?? (errBody.reason as string) ?? `HTTP ${res.status}`),
+      { status: res.status, reason: errBody.reason ?? 'SERVER_ERROR', body: errBody },
+    );
+  }
+
+  return data;
+}

--- a/src/services/facade/GameFacade.ts
+++ b/src/services/facade/GameFacade.ts
@@ -33,14 +33,14 @@ import type { RoleRevealAnimation } from '@werewolf/game-engine/types/RoleReveal
 import { randomHex } from '@werewolf/game-engine/utils/id';
 
 import { AudioService } from '@/services/infra/AudioService';
-import { RoomService } from '@/services/infra/RoomService';
-import { RealtimeService } from '@/services/transport/RealtimeService';
 import type {
   FacadeStateListener,
   IGameFacade,
   ReconnectTrigger,
 } from '@/services/types/IGameFacade';
 import { ConnectionStatus } from '@/services/types/IGameFacade';
+import type { IRealtimeService } from '@/services/types/IRealtimeService';
+import type { IRoomService } from '@/services/types/IRoomService';
 import { handleError } from '@/utils/errorPipeline';
 import { facadeLog } from '@/utils/logger';
 
@@ -62,18 +62,18 @@ interface GameFacadeDeps {
   /** GameStore 实例 */
   store: GameStore;
   /** RealtimeService 实例 */
-  realtimeService: RealtimeService;
+  realtimeService: IRealtimeService;
   /** AudioService 实例 */
   audioService: AudioService;
   /** RoomService 实例（DB state 持久化） */
-  roomService: RoomService;
+  roomService: IRoomService;
 }
 
 export class GameFacade implements IGameFacade {
   readonly #store: GameStore;
-  readonly #realtimeService: RealtimeService;
+  readonly #realtimeService: IRealtimeService;
   readonly #audioService: AudioService;
-  readonly #roomService: RoomService;
+  readonly #roomService: IRoomService;
   readonly #audioOrchestrator: AudioOrchestrator;
   readonly #connectionRecovery: ConnectionRecoveryManager;
   #isHost = false;

--- a/src/services/feature/AvatarUploadService.ts
+++ b/src/services/feature/AvatarUploadService.ts
@@ -1,7 +1,8 @@
 import { randomHex } from '@werewolf/game-engine/utils/id';
 
-import type { AuthService } from '@/services/infra/AuthService';
 import { isSupabaseConfigured, supabase } from '@/services/infra/supabaseClient';
+import type { IAuthService } from '@/services/types/IAuthService';
+import type { IStorageService } from '@/services/types/IStorageService';
 import { log } from '@/utils/logger';
 
 const avatarLog = log.extend('Avatar');
@@ -13,10 +14,10 @@ const avatarLog = log.extend('Avatar');
  * 涵盖 Supabase Storage API 调用和文件格式转换。
  * 不涉及游戏逻辑或游戏状态存储。
  */
-export class AvatarUploadService {
-  readonly #authService: AuthService;
+export class AvatarUploadService implements IStorageService {
+  readonly #authService: IAuthService;
 
-  constructor(authService: AuthService) {
+  constructor(authService: IAuthService) {
     this.#authService = authService;
   }
 

--- a/src/services/infra/AuthService.ts
+++ b/src/services/infra/AuthService.ts
@@ -2,6 +2,7 @@ import type { User as SupabaseUser } from '@supabase/supabase-js';
 import { getAllRoleIds, getRoleSpec } from '@werewolf/game-engine/models/roles';
 
 import { isSupabaseConfigured, supabase } from '@/services/infra/supabaseClient';
+import type { IAuthService } from '@/services/types/IAuthService';
 import { handleError } from '@/utils/errorPipeline';
 import { authLog } from '@/utils/logger';
 import { withTimeout } from '@/utils/withTimeout';
@@ -13,7 +14,7 @@ import { withTimeout } from '@/utils/withTimeout';
  * 管理用户昵称和头像元数据。涵盖 Supabase Auth API 调用和用户元数据管理。
  * 不涉及游戏逻辑或游戏状态存储。
  */
-export class AuthService {
+export class AuthService implements IAuthService {
   #currentUserId: string | null = null;
   readonly #initPromise: Promise<void>;
 

--- a/src/services/infra/RoomService.ts
+++ b/src/services/infra/RoomService.ts
@@ -18,16 +18,12 @@
 import type { GameState } from '@werewolf/game-engine/protocol/types';
 
 import { isSupabaseConfigured, supabase } from '@/services/infra/supabaseClient';
+import type { IRoomService, RoomRecord } from '@/services/types/IRoomService';
 import { handleError } from '@/utils/errorPipeline';
 import { roomLog } from '@/utils/logger';
 import { generateRoomCode } from '@/utils/roomCode';
 
-// Minimal room record stored in Supabase
-export interface RoomRecord {
-  roomNumber: string;
-  hostUid: string;
-  createdAt: Date;
-}
+export type { RoomRecord } from '@/services/types/IRoomService';
 
 // Database row format
 interface DbRoomRecord {
@@ -38,7 +34,7 @@ interface DbRoomRecord {
   updated_at: string;
 }
 
-export class RoomService {
+export class RoomService implements IRoomService {
   constructor() {}
 
   #isConfigured(): boolean {

--- a/src/services/registry.ts
+++ b/src/services/registry.ts
@@ -1,0 +1,76 @@
+/**
+ * ServiceRegistry - 服务工厂，根据后端配置实例化基础服务
+ *
+ * 读取 EXPO_PUBLIC_BACKEND env flag（'supabase' | 'cloudflare'）决定使用哪套实现。
+ * Phase 0 仅包含 Supabase 实现，Cloudflare 分支 throw 'Not implemented'。
+ * 由 App.tsx composition root 调用，不含业务逻辑。
+ */
+
+import { GameStore } from '@werewolf/game-engine/engine/store';
+
+import type { ServiceContextValue } from '@/contexts/ServiceContext';
+import { GameFacade } from '@/services/facade/GameFacade';
+import { AvatarUploadService } from '@/services/feature/AvatarUploadService';
+import { SettingsService } from '@/services/feature/SettingsService';
+import { AudioService } from '@/services/infra/AudioService';
+import { AuthService } from '@/services/infra/AuthService';
+import { RoomService } from '@/services/infra/RoomService';
+import { RealtimeService } from '@/services/transport/RealtimeService';
+import type { IAuthService } from '@/services/types/IAuthService';
+import type { IGameFacade } from '@/services/types/IGameFacade';
+import type { IRealtimeService } from '@/services/types/IRealtimeService';
+import type { IRoomService } from '@/services/types/IRoomService';
+import type { IStorageService } from '@/services/types/IStorageService';
+
+type BackendType = 'supabase' | 'cloudflare';
+
+const BACKEND: BackendType =
+  (process.env.EXPO_PUBLIC_BACKEND as BackendType | undefined) ?? 'supabase';
+
+/** 创建基础服务实例（auth / room / realtime / storage / settings / audio） */
+function createSupabaseServices(): {
+  services: ServiceContextValue;
+  realtimeService: IRealtimeService;
+} {
+  const authService: IAuthService = new AuthService();
+  const roomService: IRoomService = new RoomService();
+  const settingsService = new SettingsService();
+  const audioService = new AudioService();
+  const avatarUploadService: IStorageService = new AvatarUploadService(authService);
+  const realtimeService: IRealtimeService = new RealtimeService();
+
+  return {
+    services: { authService, roomService, settingsService, audioService, avatarUploadService },
+    realtimeService,
+  };
+}
+
+/** 创建 GameFacade（依赖基础服务） */
+function createFacade(
+  services: ServiceContextValue,
+  realtimeService: IRealtimeService,
+): IGameFacade {
+  return new GameFacade({
+    store: new GameStore(),
+    realtimeService,
+    audioService: services.audioService,
+    roomService: services.roomService,
+  });
+}
+
+/**
+ * 顶层入口：创建全部 services + facade。
+ * App.tsx composition root 调用一次。
+ */
+export function createAllServices(): {
+  services: ServiceContextValue;
+  facade: IGameFacade;
+} {
+  if (BACKEND === 'cloudflare') {
+    throw new Error('Cloudflare backend not yet implemented');
+  }
+
+  const { services, realtimeService } = createSupabaseServices();
+  const facade = createFacade(services, realtimeService);
+  return { services, facade };
+}

--- a/src/services/registry.ts
+++ b/src/services/registry.ts
@@ -2,13 +2,16 @@
  * ServiceRegistry - 服务工厂，根据后端配置实例化基础服务
  *
  * 读取 EXPO_PUBLIC_BACKEND env flag（'supabase' | 'cloudflare'）决定使用哪套实现。
- * Phase 0 仅包含 Supabase 实现，Cloudflare 分支 throw 'Not implemented'。
  * 由 App.tsx composition root 调用，不含业务逻辑。
  */
 
 import { GameStore } from '@werewolf/game-engine/engine/store';
 
 import type { ServiceContextValue } from '@/contexts/ServiceContext';
+import { CFAuthService } from '@/services/cloudflare/CFAuthService';
+import { CFRealtimeService } from '@/services/cloudflare/CFRealtimeService';
+import { CFRoomService } from '@/services/cloudflare/CFRoomService';
+import { CFStorageService } from '@/services/cloudflare/CFStorageService';
 import { GameFacade } from '@/services/facade/GameFacade';
 import { AvatarUploadService } from '@/services/feature/AvatarUploadService';
 import { SettingsService } from '@/services/feature/SettingsService';
@@ -45,6 +48,25 @@ function createSupabaseServices(): {
   };
 }
 
+/** 创建 Cloudflare Workers 基础服务实例 */
+function createCloudflareServices(): {
+  services: ServiceContextValue;
+  realtimeService: IRealtimeService;
+} {
+  const authService: IAuthService = new CFAuthService();
+  const roomService: IRoomService = new CFRoomService();
+  const settingsService = new SettingsService();
+  const audioService = new AudioService();
+  // CFStorageService reads token from cfFetch's tokenProvider (set by CFAuthService constructor)
+  const avatarUploadService: IStorageService = new CFStorageService();
+  const realtimeService: IRealtimeService = new CFRealtimeService();
+
+  return {
+    services: { authService, roomService, settingsService, audioService, avatarUploadService },
+    realtimeService,
+  };
+}
+
 /** 创建 GameFacade（依赖基础服务） */
 function createFacade(
   services: ServiceContextValue,
@@ -67,7 +89,9 @@ export function createAllServices(): {
   facade: IGameFacade;
 } {
   if (BACKEND === 'cloudflare') {
-    throw new Error('Cloudflare backend not yet implemented');
+    const { services, realtimeService } = createCloudflareServices();
+    const facade = createFacade(services, realtimeService);
+    return { services, facade };
   }
 
   const { services, realtimeService } = createSupabaseServices();

--- a/src/services/transport/RealtimeService.ts
+++ b/src/services/transport/RealtimeService.ts
@@ -18,10 +18,8 @@ import type { GameState } from '@werewolf/game-engine/protocol/types';
 
 import { isSupabaseConfigured, supabase } from '@/services/infra/supabaseClient';
 import { ConnectionStatus } from '@/services/types/IGameFacade';
+import type { ConnectionStatusListener, IRealtimeService } from '@/services/types/IRealtimeService';
 import { realtimeLog } from '@/utils/logger';
-
-/** Status change listener */
-type ConnectionStatusListener = (status: ConnectionStatus) => void;
 
 /** Cached joinRoom params for rejoinCurrentRoom (dead channel recovery) */
 interface JoinRoomParams {
@@ -34,7 +32,7 @@ interface JoinRoomParams {
 // Service Implementation
 // =============================================================================
 
-export class RealtimeService {
+export class RealtimeService implements IRealtimeService {
   /** Single postgres_changes channel for state synchronization + connection detection */
   #channel: RealtimeChannel | null = null;
 

--- a/src/services/types/IAuthService.ts
+++ b/src/services/types/IAuthService.ts
@@ -1,0 +1,88 @@
+/**
+ * IAuthService - 认证服务接口
+ *
+ * 定义认证服务的公共 API 契约，覆盖匿名登录、邮箱认证、用户资料管理。
+ * Supabase 和 Cloudflare 实现均需满足此接口。
+ * 不涉及游戏逻辑或游戏状态存储。
+ */
+
+/**
+ * 抽象用户类型 — 去除对 @supabase/supabase-js 的 User 类型依赖。
+ * 仅包含业务代码实际读取的字段。
+ */
+export interface AuthUser {
+  id: string;
+  email?: string | null;
+  is_anonymous?: boolean;
+  user_metadata?: Record<string, unknown>;
+}
+
+/**
+ * getCurrentUser() 返回值。
+ * 与 Supabase `auth.getUser()` 返回值结构兼容，但不引用 Supabase 类型。
+ */
+export interface GetCurrentUserResponse {
+  data: { user: AuthUser | null };
+}
+
+export interface IAuthService {
+  /** 等待初始化完成（session 恢复 / 自动登录） */
+  waitForInit(): Promise<void>;
+
+  /**
+   * 确保已认证：优先恢复 session，fallback 匿名登录。
+   * 网络失败时 throw。
+   */
+  ensureAuthenticated(): Promise<string>;
+
+  /** Supabase 是否已配置（环境变量齐全 + client 已初始化） */
+  isConfigured(): boolean;
+
+  /** 当前用户 ID（同步读取缓存值） */
+  getCurrentUserId(): string | null;
+
+  /**
+   * 获取当前用户完整信息。
+   * 未配置时返回 null。
+   */
+  getCurrentUser(): Promise<GetCurrentUserResponse> | null;
+
+  /** 匿名登录，返回 userId */
+  signInAnonymously(): Promise<string>;
+
+  /** 邮箱注册（匿名用户升级 or 新建账户） */
+  signUpWithEmail(
+    email: string,
+    password: string,
+    displayName?: string,
+  ): Promise<{ userId: string; user: AuthUser | null }>;
+
+  /** 邮箱密码登录，返回 userId */
+  signInWithEmail(email: string, password: string): Promise<string>;
+
+  /** 更新用户资料（昵称 / 头像 / 头像框） */
+  updateProfile(updates: {
+    displayName?: string;
+    avatarUrl?: string;
+    customAvatarUrl?: string;
+    avatarFrame?: string;
+  }): Promise<void>;
+
+  /** 登出 */
+  signOut(): Promise<void>;
+
+  /** 从本地 session 恢复认证，返回 userId 或 null */
+  initAuth(): Promise<string | null>;
+
+  /** 根据 uid hash 生成随机中文昵称 */
+  generateDisplayName(uid: string): string;
+
+  /** 获取当前用户昵称 */
+  getCurrentDisplayName(): Promise<string>;
+
+  /** 获取当前用户头像 URL */
+  getCurrentAvatarUrl(): Promise<string | null>;
+
+  /** 获取当前用户头像框 ID */
+  getCurrentAvatarFrame(): Promise<string | null>;
+}

--- a/src/services/types/IRealtimeService.ts
+++ b/src/services/types/IRealtimeService.ts
@@ -1,0 +1,50 @@
+/**
+ * IRealtimeService - Realtime 传输服务接口
+ *
+ * 定义房间实时通道的公共 API 契约（subscribe / unsubscribe / 连接状态）。
+ * Supabase (postgres_changes) 和 Cloudflare (Durable Objects WebSocket) 实现均需满足此接口。
+ * 不包含游戏逻辑，不持久化游戏状态。
+ */
+
+import type { GameState } from '@werewolf/game-engine/protocol/types';
+
+import type { ConnectionStatus } from '@/services/types/IGameFacade';
+
+/** 连接状态变更监听器 */
+export type ConnectionStatusListener = (status: ConnectionStatus) => void;
+
+export interface IRealtimeService {
+  /**
+   * 订阅连接状态变化。立即通知当前状态。
+   * @returns 取消订阅函数
+   */
+  addStatusListener(listener: ConnectionStatusListener): () => void;
+
+  /**
+   * 加入房间的实时通道。
+   * 若已在其他房间则自动 leaveRoom。
+   */
+  joinRoom(
+    roomCode: string,
+    userId: string,
+    callbacks: {
+      /** DB state 变更回调 */
+      onDbStateChange?: (state: GameState, revision: number) => void;
+    },
+  ): Promise<void>;
+
+  /**
+   * 标记连接为 Live（收到第一条 state 后调用）。
+   * 仅 Syncing → Live 有效，Connecting 状态不接受。
+   */
+  markAsLive(): void;
+
+  /**
+   * 死通道恢复：销毁当前通道并重建。
+   * 使用 joinRoom 时缓存的参数。
+   */
+  rejoinCurrentRoom(): Promise<void>;
+
+  /** 离开当前房间（清理通道 + status → Disconnected） */
+  leaveRoom(): Promise<void>;
+}

--- a/src/services/types/IRoomService.ts
+++ b/src/services/types/IRoomService.ts
@@ -1,0 +1,53 @@
+/**
+ * IRoomService - 房间记录 + 游戏状态持久化接口
+ *
+ * 定义房间 CRUD 和 game_state 读写的公共 API 契约。
+ * Supabase 和 Cloudflare (D1) 实现均需满足此接口。
+ * 不校验游戏逻辑，不涉及 realtime 传输。
+ */
+
+import type { GameState } from '@werewolf/game-engine/protocol/types';
+
+/** 房间记录（面向消费者的抽象） */
+export interface RoomRecord {
+  roomNumber: string;
+  hostUid: string;
+  createdAt: Date;
+}
+
+export interface IRoomService {
+  /**
+   * 创建房间（乐观插入 + 冲突重试）。
+   * @param hostUid - Host 用户 ID
+   * @param initialRoomNumber - 尝试的初始房间号
+   * @param maxRetries - 冲突重试上限（默认 5）
+   * @param buildInitialState - 可选的初始 state 构建器
+   */
+  createRoom(
+    hostUid: string,
+    initialRoomNumber?: string,
+    maxRetries?: number,
+    buildInitialState?: (roomCode: string) => GameState,
+  ): Promise<RoomRecord>;
+
+  /** 查询房间记录，不存在返回 null */
+  getRoom(roomNumber: string): Promise<RoomRecord | null>;
+
+  /** 检查房间是否存在 */
+  roomExists(roomNumber: string): Promise<boolean>;
+
+  /** 删除房间 */
+  deleteRoom(roomNumber: string): Promise<void>;
+
+  /**
+   * 持久化 game_state snapshot（供断线恢复）。
+   * Fire-and-forget 语义：失败只 warn，不阻塞游戏。
+   */
+  upsertGameState(roomCode: string, state: GameState, revision: number): Promise<void>;
+
+  /** 读取 state_revision（轻量级轮询） */
+  getStateRevision(roomCode: string): Promise<number | null>;
+
+  /** 读取完整 game_state + revision */
+  getGameState(roomCode: string): Promise<{ state: GameState; revision: number } | null>;
+}

--- a/src/services/types/IStorageService.ts
+++ b/src/services/types/IStorageService.ts
@@ -1,0 +1,17 @@
+/**
+ * IStorageService - 文件存储服务接口
+ *
+ * 定义头像上传的公共 API 契约。
+ * Supabase Storage 和 Cloudflare R2 实现均需满足此接口。
+ * 不涉及游戏逻辑或认证逻辑（认证由 IAuthService 管理）。
+ */
+
+export interface IStorageService {
+  /**
+   * 上传头像图片，返回公开可访问的 URL。
+   * 内部处理压缩、去重、旧文件清理。
+   * @param fileUri - 本地文件 URI（如 `file:///path/to/image.jpg`）
+   * @returns 公开 URL
+   */
+  uploadAvatar(fileUri: string): Promise<string>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "**/*.tsx"
   ],
   "exclude": [
-    "supabase/functions"
+    "supabase/functions",
+    "packages/api-worker"
   ]
 }


### PR DESCRIPTION
# Supabase → Cloudflare 全栈迁移

## 动机

- 中国用户需要低延迟访问（Supabase 服务器在美国，Edge Function ~270ms，中国估计 ~1-1.5s）
- Cloudflare 有中国节点，Durable Objects WebSocket 直连边缘，预计操作延迟降到 50-150ms
- 前端已迁移到 Cloudflare Pages，后端统一到 CF 减少跨平台复杂度
- 为微信小程序 `<web-view>` 方案提供更好的体验

## 当前 Supabase 依赖清单

| 功能 | 当前实现 | CF 替代 |
|------|---------|---------|
| 数据库 (rooms CRUD, game_state) | PostgreSQL + PostgREST | **D1** (SQLite) |
| 实时广播 (game state sync) | Realtime `postgres_changes` | **Durable Objects** + WebSocket |
| 匿名/邮箱 Auth | Supabase Auth | **自实现** (D1 + Workers) |
| Edge Functions (game logic) | Deno Runtime | **Workers** (调用 DO 方法) |
| 文件存储 (avatars) | Supabase Storage | **R2** |
| AI Chat 代理 | Edge Function `gemini-proxy` | **Workers** |

## 涉及文件（按现有架构层）

### 配置层
- `src/config/supabase.ts` → 改为 CF Worker URL 配置
- `src/config/api.ts` → API_BASE_URL 改为 Worker 端点

### 客户端单例
- `src/services/infra/supabaseClient.ts` → 删除，WebSocket 连接在 Transport 层管理

### 基础设施服务 (`src/services/infra/`)
- `AuthService.ts` — 29 个方法，使用 `supabase.auth.*`，改为调 Worker API
- `RoomService.ts` — 7 个方法，使用 `supabase.from('rooms').*`，改为调 Worker API
- `AudioService.ts` — 无 Supabase 依赖，不动

### 传输层 (`src/services/transport/`)
- `RealtimeService.ts` — 全部重写，Supabase Realtime channel → 原生 WebSocket 连接到 DO

### 功能服务 (`src/services/feature/`)
- `AvatarUploadService.ts` — `supabase.storage.*` → R2 via Worker API
- `AIChatService.ts` — fetch URL 从 Supabase Edge Function → CF Worker

### 编排层 (`src/services/facade/`)
- `apiUtils.ts` — HTTP POST 目标 URL 变化
- `GameFacade.ts` — 间接依赖，接口不变
- `ConnectionRecoveryManager.ts` — 断线恢复适配 WebSocket
- `AudioOrchestrator.ts` — connection status 接口适配

### Context 层
- `AuthContext.tsx` — `supabase.auth.onAuthStateChange` → 自实现 auth 事件

### 服务端
- `supabase/functions/` → `workers/` (新目录)
- `supabase/migrations/` → D1 migration SQL

### game-engine 包
- **不动** — 纯逻辑包，不依赖 Supabase

---

## 迁移阶段 & Commit 计划

### Phase 0: 抽象层（不改行为，为替换做准备）

```
commit: refactor(services): extract ITransport interface from RealtimeService
  - 新增 src/services/transport/ITransport.ts (接口定义)
  - RealtimeService implements ITransport
  - 消费者通过接口引用

commit: refactor(services): extract IAuthService interface from AuthService
  - 新增 src/services/infra/IAuthService.ts
  - AuthService implements IAuthService
  - AuthContext 通过接口引用

commit: refactor(services): extract IRoomService interface from RoomService
  - 新增 src/services/infra/IRoomService.ts
  - RoomService implements IRoomService

commit: refactor(services): extract IStorageService interface from AvatarUploadService
  - 新增 src/services/feature/IStorageService.ts
  - 分离 storage 操作为独立接口

commit: refactor(services): add ServiceRegistry for dependency injection
  - 新增 src/services/ServiceRegistry.ts
  - 所有服务通过 registry 获取，不直接 import 实现类
  - 默认注册 Supabase 实现，CF 实现后可切换
```

### Phase 1: D1 数据库 + Workers API

```
commit: feat(workers): scaffold Cloudflare Workers project structure
  - 新增 workers/ 目录
  - 新增 workers/wrangler.json (D1 binding, DO binding, R2 binding)
  - 新增 workers/src/index.ts (router)
  - 新增 workers/package.json

commit: feat(workers): D1 schema and migrations
  - 新增 workers/migrations/0001_rooms.sql
    - rooms: id, code, host_uid, template, game_state (TEXT/JSON), state_revision, created_at
  - 新增 workers/migrations/0002_users.sql
    - users: id (UUID), email, password_hash, display_name, avatar_url, created_at

commit: feat(workers): implement room CRUD API handlers
  - 新增 workers/src/handlers/rooms.ts
    - POST /rooms, GET /rooms/:code, DELETE /rooms/:code
    - PUT /rooms/:code/state, GET /rooms/:code/state
  - 对齐 RoomService 的 7 个方法语义

commit: feat(workers): implement auth API handlers
  - 新增 workers/src/handlers/auth.ts
    - POST /auth/anonymous, POST /auth/signup, POST /auth/signin
    - PUT /auth/profile, POST /auth/signout
  - JWT 用 Workers Web Crypto API 签发
  - 匿名→邮箱 identity linking

commit: feat(workers): implement game action processor
  - 新增 workers/src/handlers/game.ts
  - 复用 @werewolf/game-engine
  - processGameAction: D1 读 → game-engine → D1 写 + 乐观锁

commit: feat(services): implement CFRoomService (D1 backend)
  - 新增 src/services/infra/CFRoomService.ts implements IRoomService

commit: feat(services): implement CFAuthService (Workers backend)
  - 新增 src/services/infra/CFAuthService.ts implements IAuthService
  - JWT 本地存储 (AsyncStorage)
```

### Phase 2: Durable Objects + WebSocket 实时广播

```
commit: feat(workers): implement GameRoom Durable Object
  - 新增 workers/src/durable-objects/GameRoom.ts
  - 每房间一个 DO 实例（roomCode 为 ID）
  - WebSocket handler: accept → 加入房间 → 广播
  - 内存缓存 game_state，变更后异步写 D1
  - alarm() 定时清理过期房间

commit: feat(workers): game actions via DO instead of direct D1
  - Worker → DO.fetch() → DO 内存读写 → WebSocket 广播 → 异步写 D1

commit: feat(services): implement CFRealtimeService (DO WebSocket)
  - 新增 src/services/transport/CFRealtimeService.ts implements ITransport
  - 原生 WebSocket → DO
  - 心跳 ping/pong, 连接状态跟踪

commit: refactor(services): adapt ConnectionRecoveryManager for WebSocket
  - 6 层简化为 3 层：WS ping/pong + 重连 + DB 拉取
```

### Phase 3: R2 存储 + AI Chat

```
commit: feat(workers): implement avatar upload via R2
  - 新增 workers/src/handlers/avatars.ts

commit: feat(workers): implement Gemini proxy handler
  - 新增 workers/src/handlers/gemini-proxy.ts (SSE streaming)

commit: feat(services): implement CFStorageService (R2 backend)
  - 新增 src/services/feature/CFStorageService.ts implements IStorageService

commit: refactor(services): update AIChatService to use Worker endpoint
```

### Phase 4: 集成切换 + 测试

```
commit: feat(services): switch ServiceRegistry to CF implementations
  - 默认注册 CF 实现
  - 保留 Supabase 实现（env flag 可切回）

commit: test: update unit tests for CF service implementations

commit: test: update E2E tests for CF backend
  - CI: wrangler dev 启动本地 Worker

commit: fix: address integration issues (预留)
```

### Phase 5: 清理

```
commit: chore: remove Supabase dependencies
  - 删除 supabase/ 目录
  - 删除 Supabase 版 service 实现
  - 卸载 @supabase/supabase-js
  - 清理 CI 配置

commit: docs: update architecture documentation for CF stack
```

---

## 技术决策

| 决策 | 选择 | 原因 |
|------|------|------|
| DB | D1 (SQLite) | CF 原生，免费额度够，game_state 存 JSON TEXT |
| 实时 | Durable Objects WebSocket | 每房间单实例，天然单线程无并发，内存操作极快 |
| Auth | 自实现 JWT | 现有 auth 逻辑简单（匿名 + 邮箱），不需要第三方库 |
| 文件存储 | R2 | CF 原生，免费 10GB，S3 兼容 API |
| game-engine | 不动 | 纯 TS 逻辑包，Workers 里直接 import |
| AI proxy | Workers handler | 逻辑从 Deno → Workers，改动极小 |
| 过渡期 | ServiceRegistry + env flag | 可随时切回 Supabase，降低风险 |

## 风险

| 风险 | 缓解 |
|------|------|
| D1 SQLite 与 PostgreSQL 语法差异 | Schema 简单（1 张 rooms + 1 张 users），提前验证 |
| DO 冷启动延迟 | DO 冷启动 ~50ms，远低于 Edge Function ~270ms |
| WebSocket 断线恢复复杂度 | 6 层架构简化为 3 层 |
| 测试覆盖 | Phase 0 抽象层期间所有测试通过，逐步替换 |
| 回滚 | ServiceRegistry 保留 Supabase 实现，env flag 切换 |

## 验收标准

- [ ] 所有游戏流程在 CF 后端正常运行
- [ ] WebSocket 广播延迟 &lt; 100ms（美国）/ &lt; 200ms（中国）
- [ ] 断线恢复正常
- [ ] Auth 流程正常（匿名 → 邮箱绑定 → 重新登录）
- [ ] 头像上传/下载正常
- [ ] AI Chat 正常
- [ ] E2E 测试全部通过
- [ ] 中国用户延迟实测 &lt; 200ms